### PR TITLE
adds a bunch APIs to make things more practically useful

### DIFF
--- a/nlprule/src/rule/engine/composition.rs
+++ b/nlprule/src/rule/engine/composition.rs
@@ -436,7 +436,7 @@ impl<'t> MatchGraph<'t> {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Part {
     pub atom: Atom,
     pub quantifier: Quantifier,
@@ -444,7 +444,7 @@ pub struct Part {
     pub visible: bool,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Composition {
     pub(crate) parts: Vec<Part>,
     pub(crate) group_ids_to_idx: DefaultHashMap<usize, usize>,

--- a/nlprule/src/rule/engine/mod.rs
+++ b/nlprule/src/rule/engine/mod.rs
@@ -4,7 +4,7 @@ pub mod composition;
 
 use composition::{Composition, Group, MatchGraph};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct TokenEngine {
     pub(crate) composition: Composition,
     pub(crate) antipatterns: Vec<Composition>,
@@ -48,7 +48,7 @@ impl TokenEngine {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub enum Engine {
     Token(TokenEngine),
     Text(SerializeRegex, DefaultHashMap<usize, usize>),

--- a/nlprule/src/rule/mod.rs
+++ b/nlprule/src/rule/mod.rs
@@ -9,6 +9,7 @@ use crate::{
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+use std::fmt;
 
 pub(crate) mod disambiguation;
 pub(crate) mod engine;
@@ -229,7 +230,7 @@ impl DisambiguationRule {
 ///     <example correction="doesn't">He <marker>dosn't</marker> know about it.</example>
 /// </rule>
 /// ```
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Rule {
     pub(crate) id: String,
     pub(crate) engine: Engine,
@@ -245,6 +246,12 @@ pub struct Rule {
     pub(crate) category_id: String,
     pub(crate) category_name: String,
     pub(crate) category_type: Option<String>,
+}
+
+impl fmt::Display for Rule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.id.as_str(), self.name.as_str())
+    }
 }
 
 impl Rule {

--- a/nlprule/src/rules.rs
+++ b/nlprule/src/rules.rs
@@ -48,7 +48,7 @@ impl Rules {
     }
 
     /// Creates a new rules set from a reader.
-    pub fn new_from<R: Read>(reader: R) -> bincode::Result<Self> {
+    pub fn from_reader<R: Read>(reader: R) -> bincode::Result<Self> {
         bincode::deserialize_from(reader)
     }
 

--- a/nlprule/src/rules.rs
+++ b/nlprule/src/rules.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     fs::File,
     io::{BufReader, Read},
+    iter::{IntoIterator, FromIterator, Iterator},
     path::Path,
 };
 
@@ -140,8 +141,6 @@ pub fn apply_suggestions(text: &str, suggestions: &[Suggestion]) -> String {
 
     chars.into_iter().collect()
 }
-
-use std::iter::{IntoIterator, FromIterator, Iterator};
 
 /// A wrapping helper iterator.
 pub struct RulesIter<'a> {

--- a/nlprule/src/tokenizer.rs
+++ b/nlprule/src/tokenizer.rs
@@ -139,7 +139,7 @@ impl Tokenizer {
     }
 
     /// Creates a new tokenizer from a reader.
-    pub fn new_from<R: Read>(reader: R) -> bincode::Result<Self> {
+    pub fn from_reader<R: Read>(reader: R) -> bincode::Result<Self> {
         bincode::deserialize_from(reader)
     }
 

--- a/nlprule/src/utils/regex.rs
+++ b/nlprule/src/utils/regex.rs
@@ -14,7 +14,7 @@ fn unescape<S: AsRef<str>>(string: S, c: &str) -> String {
         .replace(placeholder, r"\\")
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 struct RegexFields {
     regex_str: String,
     case_sensitive: bool,


### PR DESCRIPTION
Breaks API in bunch of places.

Renames `new_from` to `from_reader` in order to align better with common rust naming.
Adds iterators for `Rules`.
Adds `derive(Debug)` to rules related types.