### PR TITLE
use srx for sentence boundary detection

### DIFF
--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -1,17 +1,17 @@
 import pytest
 import pickle
-from nlprule import Tokenizer, Rules, SplitOn
+from nlprule import Tokenizer, Rules
 
 
 @pytest.fixture()
 def tokenizer_and_rules():
     tokenizer = Tokenizer("storage/en_tokenizer.bin")
-    rules = Rules("storage/en_rules.bin", tokenizer, SplitOn([".", "?", "!"]))
+    rules = Rules("storage/en_rules.bin", tokenizer)
     return tokenizer, rules
 
 
 def test_correct(tokenizer_and_rules):
-    (tokenizer, rules) = tokenizer_and_rules
+    (_, rules) = tokenizer_and_rules
 
     # just some sample corrections, tests covering all rules are done in rust
 
@@ -31,8 +31,18 @@ def test_correct(tokenizer_and_rules):
     assert rules.correct("I can due his homework.") == "I can do his homework."
 
 
+def test_sentencization_sane(tokenizer_and_rules):
+    (tokenizer, _) = tokenizer_and_rules
+
+    sentences = tokenizer.pipe(
+        "e.g. U.K. and Mr. do not split. SRX is a rule-based format."
+    )
+    assert (sentences[0][-2].text, sentences[0][-1].text) == ("split", ".")
+    assert (sentences[1][1].text, sentences[1][2].text) == ("SRX", "is")
+
+
 def test_suggest(tokenizer_and_rules):
-    (tokenizer, rules) = tokenizer_and_rules
+    (_, rules) = tokenizer_and_rules
 
     text = "She was not been here since Monday instead off working."
 
@@ -52,7 +62,7 @@ def test_suggest(tokenizer_and_rules):
 
 
 def test_rules_inspectable(tokenizer_and_rules):
-    (tokenizer, rules) = tokenizer_and_rules
+    (_, rules) = tokenizer_and_rules
 
     suggestion = rules.suggest("He was taken back by my response.")[0]
 

--- a/nlprule/Cargo.toml
+++ b/nlprule/Cargo.toml
@@ -30,6 +30,7 @@ once_cell = "1.5"
 fst = "0.4"
 aho-corasick = "0.7"
 half = { version = "1.7", features = ["serde"] }
+srx = {version = "0.1", features = ["serde"] }
 
 rayon-cond = "0.1"
 rayon = "1.5"
@@ -47,7 +48,7 @@ quickcheck = "1.0"
 quickcheck_macros = "1.0"
 
 [features]
-compile = ["serde-xml-rs", "xml-rs", "roxmltree", "serde_json"]
+compile = ["serde-xml-rs", "xml-rs", "roxmltree", "serde_json", "srx/from_xml"]
 bin = ["clap", "env_logger"]
 
 [[bin]]

--- a/nlprule/src/bin/run.rs
+++ b/nlprule/src/bin/run.rs
@@ -1,8 +1,5 @@
 use clap::Clap;
-use nlprule::{
-    rules::Rules,
-    tokenizer::{finalize, Tokenizer},
-};
+use nlprule::{rules::Rules, tokenizer::Tokenizer};
 
 #[derive(Clap)]
 #[clap(
@@ -24,11 +21,8 @@ fn main() {
     let tokenizer = Tokenizer::new(opts.tokenizer).unwrap();
     let rules = Rules::new(opts.rules).unwrap();
 
-    let incomplete_tokens = tokenizer.disambiguate(tokenizer.tokenize(&opts.text));
+    let tokens = tokenizer.pipe(&opts.text);
 
-    println!("Tokens: {:#?}", incomplete_tokens);
-    println!(
-        "Suggestions: {:#?}",
-        rules.apply(&finalize(incomplete_tokens), &tokenizer)
-    );
+    println!("Tokens: {:#?}", tokens);
+    println!("Suggestions: {:#?}", rules.suggest(&opts.text, &tokenizer));
 }

--- a/nlprule/src/compile/impls.rs
+++ b/nlprule/src/compile/impls.rs
@@ -204,6 +204,7 @@ impl Tokenizer {
         build_info: &mut BuildInfo,
         chunker: Option<chunk::Chunker>,
         multiword_tagger: Option<MultiwordTagger>,
+        sentencizer: srx::Rules,
         options: TokenizerOptions,
     ) -> Result<Self, Box<dyn Error>> {
         let rules = super::parse_structure::read_disambiguation_rules(path);
@@ -261,6 +262,7 @@ impl Tokenizer {
 
         Ok(Tokenizer {
             tagger: build_info.tagger().clone(),
+            sentencizer,
             chunker,
             multiword_tagger,
             rules,

--- a/nlprule/src/rule/engine/mod.rs
+++ b/nlprule/src/rule/engine/mod.rs
@@ -86,7 +86,7 @@ impl Engine {
                     .collect();
 
                 graph_info.sort_by(|(_, start, _), (_, end, _)| start.cmp(end));
-                let mut mask = vec![false; tokens[0].text.chars().count()];
+                let mut mask = vec![false; tokens[0].sentence.chars().count()];
 
                 for (graph, start, end) in graph_info {
                     if mask[start..end].iter().all(|x| !x) {
@@ -97,7 +97,7 @@ impl Engine {
             }
             Engine::Text(regex, id_to_idx) => {
                 // this is the entire text, NOT the text of one token
-                let text = tokens[0].text;
+                let text = tokens[0].sentence;
 
                 let mut byte_to_char_idx: DefaultHashMap<usize, usize> = text
                     .char_indices()

--- a/nlprule/src/rule/grammar.rs
+++ b/nlprule/src/rule/grammar.rs
@@ -120,7 +120,7 @@ impl Match {
         let text = graph
             .by_id(self.id)
             .unwrap_or_else(|| panic!("group must exist in graph: {}", self.id))
-            .text(graph.tokens()[0].text);
+            .text(graph.tokens()[0].sentence);
 
         let mut text = if let Some(replacer) = &self.pos_replacer {
             replacer.apply(text, tokenizer)?

--- a/nlprule/src/rule/mod.rs
+++ b/nlprule/src/rule/mod.rs
@@ -189,7 +189,10 @@ impl DisambiguationRule {
                 tokenizer.disambiguate_up_to_id(tokenizer.tokenize(text), Some(&self.id));
             let finalized = finalize(tokens_before.clone());
             let changes = self.apply(&finalized, tokenizer);
-            let mut tokens_after = tokens_before.clone();
+
+            let tokens_before: Vec<_> = tokens_before.into_iter().map(|x| x.0).collect();
+            let mut tokens_after: Vec<_> = tokens_before.clone();
+
             if !changes.is_empty() {
                 self.change(&mut tokens_after, tokenizer, changes);
             }

--- a/nlprule/src/rule/mod.rs
+++ b/nlprule/src/rule/mod.rs
@@ -23,6 +23,9 @@ pub use grammar::Example;
 
 use self::disambiguation::POSFilter;
 
+/// A *Unification* makes an otherwise matching pattern invalid if no combination of its filters
+/// matches all tokens marked with "unify".
+/// Can also be negated.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct Unification {
     pub(crate) mask: Vec<Option<bool>>,
@@ -185,6 +188,7 @@ impl DisambiguationRule {
                 disambiguation::DisambiguationExample::Changed(x) => x.text.as_str(),
             };
 
+            // by convention examples are always considered as one sentence even if the sentencizer would split
             let tokens_before =
                 tokenizer.disambiguate_up_to_id(tokenizer.tokenize(text), Some(&self.id));
             let finalized = finalize(tokens_before.clone());
@@ -429,6 +433,7 @@ impl Rule {
         let mut passes = Vec::new();
 
         for test in self.examples.iter() {
+            // by convention examples are always considered as one sentence even if the sentencizer would split
             let tokens = finalize(tokenizer.disambiguate(tokenizer.tokenize(&test.text())));
             info!("Tokens: {:#?}", tokens);
             let suggestions = self.apply(&tokens, tokenizer);

--- a/nlprule/src/tokenizer.rs
+++ b/nlprule/src/tokenizer.rs
@@ -119,13 +119,13 @@ fn get_token_strs<'t>(
 
 /// *Finalizes* the tokens by e. g. adding a specific UNKNOWN part-of-speech tag.
 /// After finalization grammatical error correction rules can be used on the tokens.
-pub fn finalize(tokens: Vec<IncompleteToken>) -> Vec<Token> {
+pub fn finalize(tokens: Vec<DisambiguatedToken>) -> Vec<Token> {
     if tokens.is_empty() {
         return Vec::new();
     }
 
-    let mut finalized = vec![Token::sent_start(tokens[0].text, tokens[0].tagger)];
-    finalized.extend(tokens.into_iter().map(|x| x.into()));
+    let mut finalized = vec![Token::sent_start(tokens[0].0.sentence, tokens[0].0.tagger)];
+    finalized.extend(tokens.into_iter().map(|x| x.0.into()));
 
     finalized
 }
@@ -184,6 +184,7 @@ impl Default for TokenizerOptions {
 pub struct Tokenizer {
     pub(crate) rules: Vec<DisambiguationRule>,
     pub(crate) chunker: Option<Chunker>,
+    pub(crate) sentencizer: srx::Rules,
     pub(crate) multiword_tagger: Option<MultiwordTagger>,
     pub(crate) tagger: Arc<Tagger>,
     pub(crate) options: TokenizerOptions,
@@ -221,14 +222,14 @@ impl Tokenizer {
         &'t self,
         mut tokens: Vec<IncompleteToken<'t>>,
         id: Option<&str>,
-    ) -> Vec<IncompleteToken<'t>> {
+    ) -> Vec<DisambiguatedToken<'t>> {
         let n = id.map_or(self.rules.len(), |id| {
             self.rules.iter().position(|x| x.id == id).unwrap()
         });
         let mut i = 0;
 
         while i < n {
-            let finalized = finalize(tokens.clone());
+            let finalized = finalize(tokens.iter().cloned().map(DisambiguatedToken).collect());
             let result = self.rules[i..n]
                 .maybe_par_iter()
                 .enumerate()
@@ -250,7 +251,7 @@ impl Tokenizer {
             }
         }
 
-        tokens
+        tokens.into_iter().map(DisambiguatedToken).collect()
     }
 
     /// Apply rule-based disambiguation to the tokens.
@@ -258,15 +259,15 @@ impl Tokenizer {
     pub fn disambiguate<'t>(
         &'t self,
         tokens: Vec<IncompleteToken<'t>>,
-    ) -> Vec<IncompleteToken<'t>> {
+    ) -> Vec<DisambiguatedToken<'t>> {
         self.disambiguate_up_to_id(tokens, None)
     }
 
-    /// Tokenize the given text. This applies chunking and tagging, but does not do disambiguation.
-    pub fn tokenize<'t>(&'t self, text: &'t str) -> Vec<IncompleteToken<'t>> {
+    /// Tokenize the given sentence. This applies chunking and tagging, but does not do disambiguation.
+    pub fn tokenize<'t>(&'t self, sentence: &'t str) -> Vec<IncompleteToken<'t>> {
         let mut current_char = 0;
         let token_strs = get_token_strs(
-            text,
+            sentence,
             &self.options.extra_split_chars,
             &self.options.extra_join_regexes,
             &self.tagger,
@@ -279,7 +280,7 @@ impl Tokenizer {
                 let ptr = x.as_ptr() as usize;
                 current_char += x.chars().count();
 
-                let byte_start = ptr - text.as_ptr() as usize;
+                let byte_start = ptr - sentence.as_ptr() as usize;
                 let trimmed = x.trim();
 
                 let is_sentence_start = i == 0;
@@ -297,10 +298,10 @@ impl Tokenizer {
                     char_span: (char_start, current_char),
                     byte_span: (byte_start, byte_start + x.len()),
                     is_sentence_end,
-                    has_space_before: text[..byte_start].ends_with(char::is_whitespace),
+                    has_space_before: sentence[..byte_start].ends_with(char::is_whitespace),
                     chunks: Vec::new(),
                     multiword_data: None,
-                    text,
+                    sentence,
                     tagger: self.tagger.as_ref(),
                 }
             })
@@ -321,6 +322,21 @@ impl Tokenizer {
         }
 
         tokens
+    }
+
+    pub fn sentencize<'t>(&'t self, text: &'t str) -> Vec<Vec<IncompleteToken<'t>>> {
+        self.sentencizer
+            .split(text)
+            .into_iter()
+            .map(|sentence| self.tokenize(sentence))
+            .collect()
+    }
+
+    pub fn pipe<'t>(&'t self, text: &'t str) -> Vec<Vec<Token<'t>>> {
+        self.sentencize(text)
+            .into_iter()
+            .map(|tokens| finalize(self.disambiguate(tokens)))
+            .collect()
     }
 }
 

--- a/nlprule/src/tokenizer.rs
+++ b/nlprule/src/tokenizer.rs
@@ -264,7 +264,8 @@ impl Tokenizer {
     }
 
     /// Tokenize the given sentence. This applies chunking and tagging, but does not do disambiguation.
-    pub fn tokenize<'t>(&'t self, sentence: &'t str) -> Vec<IncompleteToken<'t>> {
+    // NB: this is not public because it could be easily misused by passing a text instead of one sentence.
+    pub(crate) fn tokenize<'t>(&'t self, sentence: &'t str) -> Vec<IncompleteToken<'t>> {
         let mut current_char = 0;
         let token_strs = get_token_strs(
             sentence,
@@ -324,6 +325,7 @@ impl Tokenizer {
         tokens
     }
 
+    /// Splits the text into sentences and tokenizes each sentence.
     pub fn sentencize<'t>(&'t self, text: &'t str) -> Vec<Vec<IncompleteToken<'t>>> {
         self.sentencizer
             .split(text)
@@ -332,6 +334,7 @@ impl Tokenizer {
             .collect()
     }
 
+    /// Applies the entire tokenization pipeline including sentencization, tagging, chunking and disambiguation.
     pub fn pipe<'t>(&'t self, text: &'t str) -> Vec<Vec<Token<'t>>> {
         self.sentencize(text)
             .into_iter()

--- a/nlprule/src/tokenizer/chunk.rs
+++ b/nlprule/src/tokenizer/chunk.rs
@@ -667,7 +667,7 @@ impl Chunker {
     /// Populates the `.chunks` field of the passed tokens by predicting with the maximum entropy model.
     pub fn apply(&self, tokens: &mut Vec<IncompleteToken>) {
         // replacements must not change char indices
-        let text = tokens[0].text.replace('’', "\'");
+        let text = tokens[0].sentence.replace('’', "\'");
 
         let mut byte_to_char_idx: DefaultHashMap<usize, usize> = text
             .char_indices()

--- a/nlprule/src/types.rs
+++ b/nlprule/src/types.rs
@@ -168,10 +168,16 @@ pub struct IncompleteToken<'t> {
     pub has_space_before: bool,
     pub chunks: Vec<String>,
     pub multiword_data: Option<WordData<'t>>,
-    pub text: &'t str,
+    pub sentence: &'t str,
     #[derivative(PartialEq = "ignore", Debug = "ignore")]
     pub tagger: &'t Tagger,
 }
+
+/// A token to which disambiguation rules have been applied to.
+#[derive(Derivative)]
+#[derivative(Debug, PartialEq)]
+#[derive(Clone)]
+pub struct DisambiguatedToken<'t>(pub IncompleteToken<'t>);
 
 /// A finished token with all information set.
 #[derive(Derivative)]
@@ -182,14 +188,14 @@ pub struct Token<'t> {
     pub byte_span: (usize, usize),
     pub has_space_before: bool,
     pub chunks: Vec<String>,
-    pub text: &'t str,
+    pub sentence: &'t str,
     #[derivative(Debug = "ignore")]
     pub tagger: &'t Tagger,
 }
 
 impl<'t> Token<'t> {
     /// Get the special sentence start token.
-    pub fn sent_start(text: &'t str, tagger: &'t Tagger) -> Self {
+    pub fn sent_start(sentence: &'t str, tagger: &'t Tagger) -> Self {
         Token {
             word: Word::new_with_tags(
                 tagger.id_word("".into()),
@@ -204,7 +210,7 @@ impl<'t> Token<'t> {
             byte_span: (0, 0),
             has_space_before: false,
             chunks: Vec::new(),
-            text,
+            sentence,
             tagger,
         }
     }
@@ -252,7 +258,7 @@ impl<'t> From<IncompleteToken<'t>> for Token<'t> {
             char_span: data.char_span,
             has_space_before: data.has_space_before,
             chunks: data.chunks,
-            text: data.text,
+            sentence: data.sentence,
             tagger: data.tagger,
         }
     }
@@ -271,4 +277,12 @@ pub struct Suggestion {
     pub end: usize,
     /// The suggested replacement options for the text.
     pub replacements: Vec<String>,
+}
+
+impl Suggestion {
+    /// Shift `start` and `end` to the right by the specified amount.
+    pub fn rshift(&mut self, offset: usize) {
+        self.start += offset;
+        self.end += offset;
+    }
 }


### PR DESCRIPTION
This commit adds the new [`srx`](https://docs.rs/srx/) dependency to load LanguageTool's `segment.srx` to split text into sentences.

Breaking changes:
- Removes the `SplitOn` class from the Python API
- Removes `_sentence` methods from the Python API
- The `.correct` and `.suggest` methods in the public Rust API now take an arbitrary text instead of one sentence as input
- Rename the `.tokenize` method to `.pipe` in the Python API. This method now also does sentencization
- Rename the `.text ` attribute of `Token` and `IncompleteToken` to `.sentence` to avoid confusion with `.word.text`
- Make `.tokenize` in the Rust API `pub(crate)` from `pub` to prevent misuse and promote `.pipe`.

New features:
- Adds a `.pipe` method to the tokenizer which does the full tokenization pipeline (sentence splitting, tagging, chunking, disambiguation)

Fixes #15 