### PR TITLE
Add `postprocess` method to builder

### DIFF
--- a/build/Cargo.toml
+++ b/build/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["science", "text-processing"]
 [dependencies]
 flate2 = "1"
 thiserror = "1"
-zip = "0.5"
+zip = "0.5.9"
 directories = "3"
 reqwest = { version = "0.11", default_features = false, features = ["blocking", "rustls-tls"]}
 nlprule = { path = "../nlprule", features = ["compile"], version = "0.4.4-pre" } # BUILD_BINDINGS_COMMENT

--- a/build/Cargo.toml
+++ b/build/Cargo.toml
@@ -20,3 +20,4 @@ nlprule = { path = "../nlprule", features = ["compile"], version = "0.4.4-pre" }
 
 [dev-dependencies]
 tempdir = "0.3"
+smush = "0.1.5" 


### PR DESCRIPTION
This PR fixes #27 by adding a `postprocess` method which transforms each binary by applying some function (in practice probably always for compression) to it.