### PR TITLE
refactor/transform: introduce transform and improve error handling

### DIFF
--- a/build/Cargo.toml
+++ b/build/Cargo.toml
@@ -22,3 +22,4 @@ fs-err = "2.5"
 [dev-dependencies]
 tempdir = "0.3"
 smush = "0.1.5"
+env_logger = "0.8"

--- a/build/Cargo.toml
+++ b/build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nlprule-build"
 version = "0.4.5-pre"
-authors = ["Benjamin Minixhofer <bminixhofer@gmail.com>"]
+authors = ["Benjamin Minixhofer <bminixhofer@gmail.com>", "Bernhard Schuster <bernhard@ahoi.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Build tools for a fast, low-resource Natural Language Processing and Error Correction library."

--- a/build/Cargo.toml
+++ b/build/Cargo.toml
@@ -17,7 +17,9 @@ directories = "3"
 reqwest = { version = "0.11", default_features = false, features = ["blocking", "rustls-tls"]}
 nlprule = { path = "../nlprule", features = ["compile"], version = "0.4.5-pre" } # BUILD_BINDINGS_COMMENT
 # nlprule = { package = "nlprule-core", path = "../nlprule", features = ["compile"] } # BUILD_BINDINGS_UNCOMMENT
+fs-err = "2.5"
 
 [dev-dependencies]
 tempdir = "0.3"
-smush = "0.1.5" 
+smush = "0.1.5"
+brotli = "3.3.0"

--- a/build/Cargo.toml
+++ b/build/Cargo.toml
@@ -22,4 +22,4 @@ fs-err = "2.5"
 [dev-dependencies]
 tempdir = "0.3"
 smush = "0.1.5"
-brotli = "3.3.0"
+brotli = { version = "3.3.0", features = ["std"] }

--- a/build/Cargo.toml
+++ b/build/Cargo.toml
@@ -22,4 +22,3 @@ fs-err = "2.5"
 [dev-dependencies]
 tempdir = "0.3"
 smush = "0.1.5"
-brotli = { version = "3.3.0", features = ["std"] }

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -92,7 +92,6 @@ fn obtain_binary_from_github_release(
 ) -> Result<Cursor<Vec<u8>>> {
     let filename = binary.filename(lang_code);
 
-    // ... otherwise, request the data from the URL ...
     let bytes = reqwest::blocking::get(&format!(
         "https://github.com/bminixhofer/nlprule/releases/download/{}/{}.gz",
         version, filename

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -637,7 +637,7 @@ mod tests {
                     let mut tmp = Vec::new();
                     buffer.read_to_end(&mut tmp)?;
                     Ok(writer.write_all(&smush::encode(
-                        &mut tmp,
+                        &tmp,
                         smush::Codec::Gzip,
                         smush::Quality::Default,
                     )?)?)

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -171,7 +171,7 @@ fn obtain_binary_cache_or_github(
     // apply the transform if any to an intermediate buffer
     let mut reader_transformed = if let Some(transform_data_fn) = transform_data_fn {
         // TODO this is not optimal, the additional copy is a bit annoying
-        let mut intermediate = Box::new(Cursor::new(Vec::<u8>::with_capacity(4096 * 1024)));
+        let mut intermediate = Box::new(Cursor::new(Vec::<u8>::new()));
         transform_data_fn(Box::new(reader_binenc), Box::new(&mut intermediate)).map_err(Error::TransformError)?;
         intermediate
     } else {

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -494,9 +494,11 @@ impl BinaryBuilder {
         &self.outputs
     }
 
-    /// Applies the given transformation before placing a binencoded file into the cache
-    /// Allows for easier compression usage.
-    /// Modifies the cached path by the given path function.
+    /// Applies the given transformation function to the binary immediately after obtaining it.
+    /// This happens before placing the file in the cache (if any) so by using a compression
+    /// function the size of the cache directory can be reduced.
+    /// Modifies the path of the cached binaries by the given `path_fn`.
+    /// If no cache directory is set or the binaries are built from the build dir, the `path_fn` does nothing.
     ///
     /// The resulting files will then reside in the given cache dir if any.
     ///

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -385,7 +385,7 @@ impl BinaryBuilder {
                 .collect()
         } else {
             language_codes
-                .into_iter()
+                .iter()
                 .map(ToOwned::to_owned)
                 .map(ToOwned::to_owned)
                 .collect::<Vec<String>>()

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -154,7 +154,7 @@ fn obtain_binary_cache_or_github(
         version,
         lang_code,
         binary,
-        cache_dir.clone(),
+        cache_dir,
         transform_path_fn,
     )?;
 

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -309,7 +309,7 @@ impl BinaryBuilder {
             (Binary::Rules, &rules_out),
         ] {
             let out = out.to_owned().to_owned();
-            if let Err(e) = assure_binary_availability(
+            match assure_binary_availability(
                 &self.version,
                 lang_code,
                 *binary,
@@ -318,10 +318,11 @@ impl BinaryBuilder {
                 self.transform_data_fn.as_ref().map(|x| x.as_ref()),
                 out,
             ) {
-                if let Error::BinariesNotFound = e {
+                Err(e) if Error::BinariesNotFound => {
                     did_not_find_binaries = true;
                     break;
                 }
+                res => res?,
             }
         }
 

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -319,15 +319,15 @@ impl BinaryBuilder {
 
         let mut did_not_find_binaries = false;
 
-        for (binary, out) in vec![
+        for (binary, out) in &[
             (Binary::Tokenizer, &tokenizer_out),
             (Binary::Rules, &rules_out),
         ] {
-            let out = out.to_owned();
+            let out = out.to_owned().to_owned();
             if let Err(e) = assure_binary_availability(
                 &self.version,
                 lang_code,
-                binary,
+                *binary,
                 self.cache_dir.as_ref(),
                 self.transform_path_fn.as_ref().map(|x| x.as_ref()),
                 self.transform_data_fn.as_ref().map(|x| x.as_ref()),

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -30,7 +30,7 @@ pub enum Error {
     ZipError(#[from] ZipError),
     #[error("error postprocessing binaries: {0}")]
     PostprocessingError(#[source] OtherError),
-    #[error("error postprocessing binaries: {0}")]
+    #[error("error transforming binaries: {0}")]
     TransformError(#[source] OtherError),
     #[error("Collation failed")]
     CollationFailed(#[source] nlprule::compile::Error)

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -5,7 +5,6 @@ use flate2::bufread::GzDecoder;
 use fs::File;
 use fs_err as fs;
 use nlprule::{compile, rules_filename, tokenizer_filename};
-use reqwest::blocking::Response;
 use std::fs::Permissions;
 use std::{
     io::{self, BufReader, BufWriter, Cursor, Read, Write, Seek, SeekFrom},

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -161,9 +161,7 @@ fn obtain_binary_cache_or_github(
     // if the file can be read, the data is already cached and the transform was applied before
     if let Some(ref cache_path) = cache_path {
         if let Ok(bytes) = fs::read(cache_path) {
-            if bytes.len() > 256 {
-                return Ok(Box::new(Cursor::new(bytes)));
-            }
+            return Ok(Box::new(Cursor::new(bytes)));
         }
     }
 
@@ -589,6 +587,8 @@ mod tests {
 
     #[test]
     fn getting_build_dir_works() -> Result<()> {
+        let _ = env_logger::builder().is_test(true).try_init();
+
         let tempdir = tempdir::TempDir::new("build_dir_test")?;
         let tempdir = tempdir.path();
 

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -318,7 +318,7 @@ impl BinaryBuilder {
                 self.transform_data_fn.as_ref().map(|x| x.as_ref()),
                 out,
             ) {
-                Err(e) if Error::BinariesNotFound => {
+                Err(Error::BinariesNotFound) => {
                     did_not_find_binaries = true;
                     break;
                 }

--- a/nlprule/Cargo.toml
+++ b/nlprule/Cargo.toml
@@ -27,6 +27,7 @@ indexmap = { version = "1", features = ["serde"] }
 unicase = "2.6"
 derivative = "2.2"
 fst = "0.4"
+fs-err = "2.5"
 aho-corasick = "0.7"
 half = { version = "1.7", features = ["serde"] }
 srx = { version = "^0.1.2", features = ["serde"] }

--- a/nlprule/src/bin/compile.rs
+++ b/nlprule/src/bin/compile.rs
@@ -1,7 +1,8 @@
 use clap::Clap;
 use fs_err as fs;
-use nlprule::compile::{compile, BuildOptions, Error};
+use nlprule::compile::{compile, Error};
 use std::io::BufWriter;
+use std::path::PathBuf;
 
 #[derive(clap::Clap)]
 #[clap(

--- a/nlprule/src/bin/compile.rs
+++ b/nlprule/src/bin/compile.rs
@@ -1,12 +1,14 @@
 use clap::Clap;
 use nlprule::compile::{compile, BuildOptions, Error};
+use std::io::BufWriter;
+use fs_err as fs;
 
 fn main() -> Result<(), Error> {
     env_logger::init();
     let opts = BuildOptions::parse();
 
-    let tokenizer_sink = BufWriter::new(File::create(&opts.tokenizer_out)?);
-    let rules_sink = BufWriter::new(File::create(&opts.rules_out)?);
+    let tokenizer_sink = BufWriter::new(fs::File::create(&opts.tokenizer_out)?);
+    let rules_sink = BufWriter::new(fs::File::create(&opts.rules_out)?);
 
     compile(opts.build_dir, rules_sink, tokenizer_sink)
 }

--- a/nlprule/src/bin/compile.rs
+++ b/nlprule/src/bin/compile.rs
@@ -5,5 +5,8 @@ fn main() -> Result<(), Error> {
     env_logger::init();
     let opts = BuildOptions::parse();
 
-    compile(&opts)
+    let tokenizer_sink = BufWriter::new(File::create(&opts.tokenizer_out)?);
+    let rules_sink = BufWriter::new(File::create(&opts.rules_out)?);
+
+    compile(opts.build_dir, rules_sink, tokenizer_sink)
 }

--- a/nlprule/src/bin/compile.rs
+++ b/nlprule/src/bin/compile.rs
@@ -1,7 +1,7 @@
 use clap::Clap;
+use fs_err as fs;
 use nlprule::compile::{compile, BuildOptions, Error};
 use std::io::BufWriter;
-use fs_err as fs;
 
 #[derive(clap::Clap)]
 #[clap(

--- a/nlprule/src/bin/compile.rs
+++ b/nlprule/src/bin/compile.rs
@@ -3,6 +3,20 @@ use nlprule::compile::{compile, BuildOptions, Error};
 use std::io::BufWriter;
 use fs_err as fs;
 
+#[derive(clap::Clap)]
+#[clap(
+    version = env!("CARGO_PKG_VERSION"),
+    author = "Benjamin Minixhofer <bminixhofer@gmail.com>"
+)]
+pub struct BuildOptions {
+    #[clap(long, parse(from_os_str))]
+    pub build_dir: PathBuf,
+    #[clap(long, parse(from_os_str))]
+    pub tokenizer_out: PathBuf,
+    #[clap(long, parse(from_os_str))]
+    pub rules_out: PathBuf,
+}
+
 fn main() -> Result<(), Error> {
     env_logger::init();
     let opts = BuildOptions::parse();

--- a/nlprule/src/compile/mod.rs
+++ b/nlprule/src/compile/mod.rs
@@ -1,7 +1,7 @@
 //! Creates the nlprule binaries from a *build directory*. Usage information in /build/README.md.
 
-use fs_err as fs;
 use fs::File;
+use fs_err as fs;
 
 use std::{
     hash::{Hash, Hasher},
@@ -26,7 +26,6 @@ mod impls;
 mod parse_structure;
 mod structure;
 mod utils;
-
 
 struct BuildFilePaths {
     lang_code_path: PathBuf,
@@ -83,7 +82,11 @@ pub enum Error {
     ParseError(#[from] ParseIntError),
 }
 
-pub fn compile(build_dir: impl AsRef<Path>, mut rules_dest: impl io::Write, mut tokenizer_dest: impl io::Write) -> Result<(), Error> {
+pub fn compile(
+    build_dir: impl AsRef<Path>,
+    mut rules_dest: impl io::Write,
+    mut tokenizer_dest: impl io::Write,
+) -> Result<(), Error> {
     let paths = BuildFilePaths::new(&build_dir);
 
     let lang_code = fs::read_to_string(paths.lang_code_path)?;

--- a/nlprule/src/compile/mod.rs
+++ b/nlprule/src/compile/mod.rs
@@ -17,7 +17,6 @@ use crate::{
     tokenizer::{chunk::Chunker, multiword::MultiwordTagger, tag::Tagger, Tokenizer},
     types::DefaultHasher,
 };
-use clap::Clap;
 use log::info;
 
 use self::parse_structure::{BuildInfo, RegexCache};
@@ -28,19 +27,6 @@ mod parse_structure;
 mod structure;
 mod utils;
 
-#[derive(Clap)]
-#[clap(
-    version = env!("CARGO_PKG_VERSION"),
-    author = "Benjamin Minixhofer <bminixhofer@gmail.com>"
-)]
-pub struct BuildOptions {
-    #[clap(long, parse(from_os_str))]
-    pub build_dir: PathBuf,
-    #[clap(long, parse(from_os_str))]
-    pub tokenizer_out: PathBuf,
-    #[clap(long, parse(from_os_str))]
-    pub rules_out: PathBuf,
-}
 
 struct BuildFilePaths {
     lang_code_path: PathBuf,


### PR DESCRIPTION
Note that this PR still lacks test adjustments required and `transform` is _not_ covered yet.

Changes:

* improve the error type
* add `fs-err` for better errors without much chore
* introduce `fn transform` for transformations _before_ artifacts hit the `cache_dir` (this is not quite correct now, tbd)
* introduce a type alias `type Result<T>` to avoid boilerplate
* use `BufReader` and `BufWriter` instead of intermediate `Vec` where possible
* migrate a few elements to more idiomatic expressions