### PR TITLE
Modularize regex backend, add fancy-regex support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           args: --verbose --all-features
       - run: rustup component add clippy
       - uses: actions-rs/clippy-check@v1
+        if: matrix.lang == 'en' # only need to run this once
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
@@ -54,6 +55,22 @@ jobs:
         with:
           command: run
           args: --all-features --bin test_disambiguation -- --tokenizer storage/${{ matrix.lang }}_tokenizer.bin
+      - uses: actions-rs/cargo@v1 # run with fancy-regex backend once
+        if: matrix.lang == 'en'
+        env:
+            RUST_LOG: WARN
+        working-directory: nlprule # otherwise we can't use --features
+        with:
+          command: run
+          args: --features "bin regex-onig" --no-default-features --bin test_disambiguation -- --tokenizer storage/${{ matrix.lang }}_tokenizer.bin
+      - uses: actions-rs/cargo@v1 # run with onig backend once
+        if: matrix.lang == 'en'
+        env:
+            RUST_LOG: WARN
+        working-directory: nlprule # otherwise we can't use --features
+        with:
+          command: run
+          args: --features "bin regex-fancy" --no-default-features --bin test_disambiguation -- --tokenizer storage/${{ matrix.lang }}_tokenizer.bin
       - uses: actions-rs/cargo@v1
         env:
             RUST_LOG: WARN

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,18 +59,16 @@ jobs:
         if: matrix.lang == 'en'
         env:
             RUST_LOG: WARN
-        working-directory: nlprule # otherwise we can't use --features
         with:
           command: run
-          args: --features "bin regex-onig" --no-default-features --bin test_disambiguation -- --tokenizer storage/${{ matrix.lang }}_tokenizer.bin
+          args: --manifest-path nlprule/Cargo.toml --features "bin regex-onig" --no-default-features --bin test_disambiguation -- --tokenizer storage/${{ matrix.lang }}_tokenizer.bin
       - uses: actions-rs/cargo@v1 # run with onig backend once
         if: matrix.lang == 'en'
         env:
             RUST_LOG: WARN
-        working-directory: nlprule # otherwise we can't use --features
         with:
           command: run
-          args: --features "bin regex-fancy" --no-default-features --bin test_disambiguation -- --tokenizer storage/${{ matrix.lang }}_tokenizer.bin
+          args: --manifest-path nlprule/Cargo.toml --features "bin regex-fancy" --no-default-features --bin test_disambiguation -- --tokenizer storage/${{ matrix.lang }}_tokenizer.bin
       - uses: actions-rs/cargo@v1
         env:
             RUST_LOG: WARN
@@ -109,9 +107,7 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-      # this can cause errors because it is assumed that there
-      # are only wheels for the current python version in target/wheels
-      # - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v1
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
@@ -133,6 +129,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install maturin==0.8.3 pytest==6.1.2
          
+          # remove potentially cached wheels
+          rm target/wheels/* || true
           bash scripts/maturin.sh build --interpreter python --release --manylinux 1
 
           pip install $(ls target/wheels/* | head -n1)

--- a/nlprule/Cargo.toml
+++ b/nlprule/Cargo.toml
@@ -10,14 +10,11 @@ repository = "https://github.com/bminixhofer/nlprule"
 keywords = ["text", "spelling", "language-processing", "nlp", "grammar"]
 categories = ["science", "text-processing"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 serde = { version = "1.0", features = ["derive", "rc"] }
 bincode = "1.3"
 bimap = { version = "0.6", features = ["serde"] }
 log = "0.4"
-onig = { version = "6.1", default_features = false }
 lazy_static = "1.4"
 thiserror = "1"
 either = { version = "1.6", features = ["serde"] }
@@ -35,9 +32,16 @@ srx = { version = "^0.1.2", features = ["serde"] }
 rayon-cond = "0.1"
 rayon = "1.5"
 
+# regex backends
+onig = { version = "6.1", default_features = false, optional = true }
+fancy-regex = { version = "0.5", optional = true }
+
+# needed for the bin targets
 clap = { version = "3.0.0-beta.1", optional = true }
 env_logger = { version = "0.8", optional = true }
 
+# needed for compilation
+regex = { version = "1", optional = true }
 serde-xml-rs = { version = "0.4", optional = true }
 xml-rs = { version = "0.8", optional = true }
 roxmltree = { version = "0.14.0", optional = true }
@@ -51,8 +55,15 @@ quickcheck_macros = "1.0"
 serde_json = "1"
 
 [features]
+default = ["regex-onig"]
+
+regex-onig = ["onig"]
+# to switch to the fancy-regex engine, disable default features and add this feature
+regex-fancy = ["fancy-regex"]
+
+# needed for the bin test targets and to compile nlprule binaries, you'll usually not need these
 bin = ["clap", "env_logger"]
-compile = ["serde-xml-rs", "xml-rs", "roxmltree", "serde_json", "srx/from_xml", "bin"]
+compile = ["regex", "serde-xml-rs", "xml-rs", "roxmltree", "serde_json", "srx/from_xml", "bin"]
 
 [[bin]]
 name = "compile"

--- a/nlprule/Cargo.toml
+++ b/nlprule/Cargo.toml
@@ -69,7 +69,7 @@ regex-all-test = ["regex-onig", "regex-fancy"]
 
 # needed for the bin test targets and to compile nlprule binaries, you'll usually not need these
 bin = ["clap", "env_logger"]
-compile = ["regex-syntax", "serde-xml-rs", "xml-rs", "roxmltree", "serde_json", "srx/from_xml", "regex-all-test", "bin"]
+compile = ["regex-syntax", "serde-xml-rs", "xml-rs", "roxmltree", "serde_json", "srx/from_xml", "regex-all-test"]
 
 [[bin]]
 name = "compile"

--- a/nlprule/Cargo.toml
+++ b/nlprule/Cargo.toml
@@ -29,6 +29,7 @@ aho-corasick = "0.7"
 half = { version = "1.7", features = ["serde"] }
 srx = { version = "^0.1.2", features = ["serde"] }
 lazycell = "1"
+cfg-if = "1"
 
 rayon-cond = "0.1"
 rayon = "1.5"
@@ -62,9 +63,13 @@ regex-onig = ["onig"]
 # to switch to the fancy-regex engine, disable default features and add this feature
 regex-fancy = ["fancy-regex"]
 
+# this enables both regex backends at the same time and makes sure they are equivalent
+# used only for compilation and tests
+regex-all-test = ["regex-onig", "regex-fancy"]
+
 # needed for the bin test targets and to compile nlprule binaries, you'll usually not need these
 bin = ["clap", "env_logger"]
-compile = ["regex", "serde-xml-rs", "xml-rs", "roxmltree", "serde_json", "srx/from_xml", "bin"]
+compile = ["regex", "serde-xml-rs", "xml-rs", "roxmltree", "serde_json", "srx/from_xml", "regex-all-test", "bin"]
 
 [[bin]]
 name = "compile"

--- a/nlprule/Cargo.toml
+++ b/nlprule/Cargo.toml
@@ -28,6 +28,7 @@ fs-err = "2.5"
 aho-corasick = "0.7"
 half = { version = "1.7", features = ["serde"] }
 srx = { version = "^0.1.2", features = ["serde"] }
+lazycell = "1"
 
 rayon-cond = "0.1"
 rayon = "1.5"

--- a/nlprule/Cargo.toml
+++ b/nlprule/Cargo.toml
@@ -43,7 +43,7 @@ clap = { version = "3.0.0-beta.1", optional = true }
 env_logger = { version = "0.8", optional = true }
 
 # needed for compilation
-regex = { version = "1", optional = true }
+regex-syntax = { version = "0.6", optional = true }
 serde-xml-rs = { version = "0.4", optional = true }
 xml-rs = { version = "0.8", optional = true }
 roxmltree = { version = "0.14.0", optional = true }
@@ -69,7 +69,7 @@ regex-all-test = ["regex-onig", "regex-fancy"]
 
 # needed for the bin test targets and to compile nlprule binaries, you'll usually not need these
 bin = ["clap", "env_logger"]
-compile = ["regex", "serde-xml-rs", "xml-rs", "roxmltree", "serde_json", "srx/from_xml", "regex-all-test", "bin"]
+compile = ["regex-syntax", "serde-xml-rs", "xml-rs", "roxmltree", "serde_json", "srx/from_xml", "regex-all-test", "bin"]
 
 [[bin]]
 name = "compile"

--- a/nlprule/src/compile/impls.rs
+++ b/nlprule/src/compile/impls.rs
@@ -353,9 +353,8 @@ impl Regex {
         let regex_string =
             super::utils::from_java_regex(java_regex_str, case_sensitive, full_match)?;
 
-        let regex = Regex::new(regex_string.clone());
+        let regex = Regex::new(regex_string);
         if let Err(error) = regex.try_compile() {
-            println!("{}", regex_string);
             return Err(Error::Regex(error));
         }
 

--- a/nlprule/src/compile/mod.rs
+++ b/nlprule/src/compile/mod.rs
@@ -71,7 +71,7 @@ pub enum Error {
     #[error("config does not exist for '{lang_code}'")]
     ConfigDoesNotExist { lang_code: String },
     #[error("regex syntax error: {0}")]
-    RegexSyntax(#[from] regex_syntax::Error),
+    RegexSyntax(#[from] regex_syntax::ast::Error),
     #[error("regex compilation error: {0}")]
     Regex(Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("unexpected condition: {0}")]

--- a/nlprule/src/compile/mod.rs
+++ b/nlprule/src/compile/mod.rs
@@ -68,18 +68,18 @@ pub enum Error {
     JSON(#[from] serde_json::Error),
     #[error("error loading SRX")]
     SRX(#[from] srx::Error),
-    #[error("unknown error")]
-    Other(#[from] Box<dyn std::error::Error>),
     #[error("config does not exist for '{lang_code}'")]
     ConfigDoesNotExist { lang_code: String },
     #[error("regex compilation error: {0}")]
-    Regex(#[from] onig::Error),
+    Regex(Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("unexpected condition: {0}")]
     Unexpected(String),
     #[error("feature not implemented: {0}")]
     Unimplemented(String),
     #[error("error parsing to integer: {0}")]
     ParseError(#[from] ParseIntError),
+    #[error("unknown error")]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 pub fn compile(

--- a/nlprule/src/compile/mod.rs
+++ b/nlprule/src/compile/mod.rs
@@ -70,6 +70,8 @@ pub enum Error {
     SRX(#[from] srx::Error),
     #[error("config does not exist for '{lang_code}'")]
     ConfigDoesNotExist { lang_code: String },
+    #[error("regex syntax error: {0}")]
+    RegexSyntax(#[from] regex_syntax::Error),
     #[error("regex compilation error: {0}")]
     Regex(Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("unexpected condition: {0}")]

--- a/nlprule/src/compile/parse_structure.rs
+++ b/nlprule/src/compile/parse_structure.rs
@@ -2,9 +2,8 @@ use std::sync::Arc;
 
 use super::{structure, Error};
 use crate::{tokenizer::tag::Tagger, types::*};
-use crate::{utils, utils::regex::SerializeRegex};
+use crate::{utils, utils::regex::Regex};
 use lazy_static::lazy_static;
-use onig::Regex;
 use serde::{Deserialize, Serialize};
 
 pub use structure::{read_disambiguation_rules, read_rules};
@@ -128,7 +127,7 @@ fn parse_match_attribs(
     if text.is_some() || text_match_idx.is_some() {
         let matcher = if is_regex {
             if let Some(text) = text {
-                let regex = SerializeRegex::new(text.trim(), true, case_sensitive);
+                let regex = Regex::from_java_regex(text.trim(), true, case_sensitive);
                 Matcher::new_regex(regex?, negate, inflected)
             } else {
                 return Err(Error::Unexpected("`text` must be set if regex".into()));
@@ -166,7 +165,7 @@ fn parse_match_attribs(
 
     if let Some(postag) = attribs.postag() {
         let raw_matcher = if is_postag_regexp {
-            let regex = SerializeRegex::new(&postag.trim(), true, true);
+            let regex = Regex::from_java_regex(&postag.trim(), true, true);
             Matcher::new_regex(regex?, negate_pos, true)
         } else {
             Matcher::new_string(
@@ -206,7 +205,7 @@ fn parse_match_attribs(
             atoms.push(chunk_atom.into());
         }
         (None, Some(chunk_re)) => {
-            let regex = SerializeRegex::new(chunk_re.trim(), true, true)?;
+            let regex = Regex::from_java_regex(chunk_re.trim(), true, true)?;
             let chunk_atom = ChunkAtom {
                 matcher: Matcher::new_regex(regex, false, true),
             };
@@ -414,7 +413,7 @@ fn parse_match(m: structure::Match, engine: &Engine, info: &mut BuildInfo) -> Re
 
         let matcher = match m.postag_regex.as_deref() {
             Some("yes") => {
-                let regex = SerializeRegex::new(&postag, true, false)?;
+                let regex = Regex::from_java_regex(&postag, true, false)?;
                 Matcher::new_regex(regex, false, true)
             }
             None => Matcher::new_string(either::Left(postag), false, false, true),
@@ -429,7 +428,7 @@ fn parse_match(m: structure::Match, engine: &Engine, info: &mut BuildInfo) -> Re
 
     let regex_replacer = match (m.regexp_match, m.regexp_replace) {
         (Some(regex_match), Some(regex_replace)) => Some((
-            SerializeRegex::new(&regex_match, false, true)?,
+            Regex::from_java_regex(&regex_match, false, true)?,
             regex_replace,
         )),
         _ => None,
@@ -457,22 +456,25 @@ fn parse_match(m: structure::Match, engine: &Engine, info: &mut BuildInfo) -> Re
 
 fn parse_synthesizer_text(text: &str, engine: &Engine) -> Result<Vec<SynthesizerPart>, Error> {
     lazy_static! {
-        static ref MATCH_REGEX: Regex = Regex::new(r"\\(\d)").expect("number regex is valid");
+        static ref MATCH_REGEX: Regex = Regex::new(r"\\(\d)".into());
     }
 
     let mut parts = Vec::new();
     let mut end_index = 0;
 
     for capture in MATCH_REGEX.captures_iter(&text) {
-        let (start, end) = capture.pos(0).expect("0th regex group exists");
+        let mat = capture.get(0).expect("0th regex group exists");
 
-        if end_index != start {
-            parts.push(SynthesizerPart::Text((&text[end_index..start]).to_string()))
+        if end_index != mat.start() {
+            parts.push(SynthesizerPart::Text(
+                (&text[end_index..mat.start()]).to_string(),
+            ))
         }
 
         let id = capture
-            .at(1)
+            .get(1)
             .expect("1st regex group exists")
+            .as_str()
             .parse::<usize>()
             .expect("match regex capture must be parsable as usize.");
 
@@ -482,7 +484,7 @@ fn parse_synthesizer_text(text: &str, engine: &Engine) -> Result<Vec<Synthesizer
             pos_replacer: None,
             regex_replacer: None,
         }));
-        end_index = end;
+        end_index = mat.end();
     }
 
     if end_index < text.len() {
@@ -733,7 +735,7 @@ impl Rule {
                     x => panic!("unknown case_sensitive value {:?}", x),
                 };
                 let mark = regex.mark.map_or(Ok(0), |x| x.parse())?;
-                let regex = SerializeRegex::new(&regex.text, false, case_sensitive)?;
+                let regex = Regex::from_java_regex(&regex.text, false, case_sensitive)?;
                 let id_to_idx: DefaultHashMap<GraphId, usize> = (0..regex.captures_len() + 1)
                     .enumerate()
                     // the IDs in a regex rule are just the same as indices
@@ -899,14 +901,14 @@ impl Rule {
 
 fn parse_tag_form(form: &str, info: &mut BuildInfo) -> Result<owned::Word, Error> {
     lazy_static! {
-        static ref REGEX: Regex = Regex::new(r"(.+?)\[(.+?)\]").expect("tag form regex is valid");
+        static ref REGEX: Regex = Regex::new(r"(.+?)\[(.+?)\]".into());
     }
 
     let captures = REGEX
         .captures(form)
         .ok_or_else(|| Error::Unexpected(format!("tag form must match regex, found '{}'", form)))?;
-    let text = captures.at(1).expect("1st regex group exists").to_string();
-    let tags = captures.at(2).expect("2nd regex group exists");
+    let text = captures.get(1).expect("1st regex group exists").as_str();
+    let tags = captures.get(2).expect("2nd regex group exists").as_str();
 
     let tags = tags
         .split(',')
@@ -951,7 +953,7 @@ fn parse_pos_filter(postag: &str, postag_regexp: Option<&str>, info: &mut BuildI
     match postag_regexp.as_deref() {
         Some("yes") => POSFilter::new(PosMatcher::new(
             Matcher::new_regex(
-                SerializeRegex::new(&postag, true, true).unwrap(),
+                Regex::from_java_regex(&postag, true, true).unwrap(),
                 false,
                 true,
             ),

--- a/nlprule/src/compile/parse_structure.rs
+++ b/nlprule/src/compile/parse_structure.rs
@@ -478,12 +478,15 @@ fn parse_synthesizer_text(text: &str, engine: &Engine) -> Result<Vec<Synthesizer
             .parse::<usize>()
             .expect("match regex capture must be parsable as usize.");
 
-        parts.push(SynthesizerPart::Match(Match {
-            id: engine.to_graph_id(id)?,
-            conversion: Conversion::Nop,
-            pos_replacer: None,
-            regex_replacer: None,
-        }));
+        parts.push(SynthesizerPart::Match(
+            Match {
+                id: engine.to_graph_id(id)?,
+                conversion: Conversion::Nop,
+                pos_replacer: None,
+                regex_replacer: None,
+            }
+            .into(),
+        ));
         end_index = mat.end();
     }
 
@@ -505,7 +508,7 @@ fn parse_suggestion(
                 parts.extend(parse_synthesizer_text(text.as_str(), engine)?);
             }
             structure::SuggestionPart::Match(m) => {
-                parts.push(SynthesizerPart::Match(parse_match(m, engine, info)?));
+                parts.push(SynthesizerPart::Match(parse_match(m, engine, info)?.into()));
             }
         }
     }
@@ -741,7 +744,7 @@ impl Rule {
                     // the IDs in a regex rule are just the same as indices
                     .map(|(key, value)| (GraphId(key), value))
                     .collect();
-                Ok((Engine::Text(regex, id_to_idx), mark, mark))
+                Ok((Engine::Text(regex.into(), id_to_idx), mark, mark))
             }
         }?;
 
@@ -779,7 +782,9 @@ impl Rule {
                     message_parts.extend(parse_synthesizer_text(text.as_str(), &engine)?);
                 }
                 structure::MessagePart::Match(m) => {
-                    message_parts.push(SynthesizerPart::Match(parse_match(m, &engine, info)?));
+                    message_parts.push(SynthesizerPart::Match(
+                        parse_match(m, &engine, info)?.into(),
+                    ));
                 }
             }
         }

--- a/nlprule/src/compile/utils.rs
+++ b/nlprule/src/compile/utils.rs
@@ -398,7 +398,7 @@ mod regex {
 
         #[test]
         fn nested_quantifiers() {
-            assert!(from_java_regex(r"[0-9,.]*{1,}", false, false).is_err(),)
+            assert!(from_java_regex(r"[0-9,.]*{1,}", false, false).is_err())
         }
     }
 }

--- a/nlprule/src/compile/utils.rs
+++ b/nlprule/src/compile/utils.rs
@@ -376,7 +376,7 @@ mod regex {
         fn i_flag_removed() {
             assert_eq!(
                 from_java_regex(r"(?iu)\p{Lu}\p{Ll}+", false, false).unwrap(),
-                r"(?u)\p{Lu}\p{Ll}+"
+                r"\p{Lu}\p{Ll}+"
             )
         }
 
@@ -397,11 +397,8 @@ mod regex {
         }
 
         #[test]
-        fn consecutive_quantifiers() {
-            assert_eq!(
-                from_java_regex(r"[0-9,.]*{1,}", false, false).unwrap(),
-                r"(?<=[xX])s"
-            )
+        fn nested_quantifiers() {
+            assert!(from_java_regex(r"[0-9,.]*{1,}", false, false).is_err(),)
         }
     }
 }

--- a/nlprule/src/filter/mod.rs
+++ b/nlprule/src/filter/mod.rs
@@ -28,9 +28,8 @@ impl Filterable for NoDisambiguationEnglishPartialPosTagFilter {
     fn keep(&self, graph: &MatchGraph, tokenizer: &Tokenizer) -> bool {
         graph.by_id(self.id).tokens(graph.tokens()).all(|token| {
             if let Some(captures) = self.regexp.captures(&token.word.text.as_ref()) {
-                // get group 2 because `full_match` adds one group
                 let tags = tokenizer.tagger().get_tags(
-                    &captures.get(2).unwrap().as_str(),
+                    &captures.get(1).unwrap().as_str(),
                     tokenizer.options().always_add_lower_tags,
                     tokenizer.options().use_compound_split_heuristic,
                 );

--- a/nlprule/src/filter/mod.rs
+++ b/nlprule/src/filter/mod.rs
@@ -1,6 +1,6 @@
 use crate::rule::{engine::composition::GraphId, MatchGraph};
 use crate::tokenizer::Tokenizer;
-use crate::utils::regex::SerializeRegex;
+use crate::utils::regex::Regex;
 use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
 
@@ -18,8 +18,8 @@ pub trait Filterable {
 #[derive(Serialize, Deserialize)]
 pub struct NoDisambiguationEnglishPartialPosTagFilter {
     pub(crate) id: GraphId,
-    pub(crate) regexp: SerializeRegex,
-    pub(crate) postag_regexp: SerializeRegex,
+    pub(crate) regexp: Regex,
+    pub(crate) postag_regexp: Regex,
     #[allow(dead_code)]
     pub(crate) negate_postag: bool,
 }
@@ -30,7 +30,7 @@ impl Filterable for NoDisambiguationEnglishPartialPosTagFilter {
             if let Some(captures) = self.regexp.captures(&token.word.text.as_ref()) {
                 // get group 2 because `full_match` adds one group
                 let tags = tokenizer.tagger().get_tags(
-                    &captures.at(2).unwrap(),
+                    &captures.get(2).unwrap().as_str(),
                     tokenizer.options().always_add_lower_tags,
                     tokenizer.options().use_compound_split_heuristic,
                 );

--- a/nlprule/src/rule/engine/composition.rs
+++ b/nlprule/src/rule/engine/composition.rs
@@ -1,4 +1,4 @@
-use crate::{types::*, utils::regex::SerializeRegex};
+use crate::{types::*, utils::regex::Regex};
 use enum_dispatch::enum_dispatch;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
@@ -6,7 +6,7 @@ use unicase::UniCase;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Matcher {
-    pub matcher: either::Either<either::Either<String, GraphId>, SerializeRegex>,
+    pub matcher: either::Either<either::Either<String, GraphId>, Regex>,
     pub negate: bool,
     pub case_sensitive: bool,
     pub empty_always_false: bool,

--- a/nlprule/src/rule/engine/mod.rs
+++ b/nlprule/src/rule/engine/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     types::*,
-    utils::regex::{CapturesIter, Regex},
+    utils::regex::{CaptureMatches, Regex},
 };
 use serde::{Deserialize, Serialize};
 pub mod composition;
@@ -56,7 +56,8 @@ impl TokenEngine {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum Engine {
     Token(TokenEngine),
-    Text(Regex, DefaultHashMap<GraphId, usize>),
+    // regex with the `fancy_regex` backend is large on the stack
+    Text(Box<Regex>, DefaultHashMap<GraphId, usize>),
 }
 
 struct TokenMatches<'a> {
@@ -68,7 +69,7 @@ struct TokenMatches<'a> {
 struct TextMatches<'a, 't> {
     byte_idx_to_char_idx: DefaultHashMap<usize, usize>,
     id_to_idx: &'a DefaultHashMap<GraphId, usize>,
-    captures: CapturesIter<'a, 't>,
+    captures: CaptureMatches<'a, 't>,
 }
 
 enum InnerMatches<'a: 't, 't> {

--- a/nlprule/src/rule/engine/mod.rs
+++ b/nlprule/src/rule/engine/mod.rs
@@ -1,5 +1,7 @@
-use crate::{types::*, utils::regex::SerializeRegex};
-use onig::FindCaptures;
+use crate::{
+    types::*,
+    utils::regex::{CapturesIter, Regex},
+};
 use serde::{Deserialize, Serialize};
 pub mod composition;
 
@@ -54,7 +56,7 @@ impl TokenEngine {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum Engine {
     Token(TokenEngine),
-    Text(SerializeRegex, DefaultHashMap<GraphId, usize>),
+    Text(Regex, DefaultHashMap<GraphId, usize>),
 }
 
 struct TokenMatches<'a> {
@@ -66,7 +68,7 @@ struct TokenMatches<'a> {
 struct TextMatches<'a, 't> {
     byte_idx_to_char_idx: DefaultHashMap<usize, usize>,
     id_to_idx: &'a DefaultHashMap<GraphId, usize>,
-    captures: FindCaptures<'a, 't>,
+    captures: CapturesIter<'a, 't>,
 }
 
 enum InnerMatches<'a: 't, 't> {
@@ -112,13 +114,13 @@ impl<'a, 't> Iterator for EngineMatches<'a, 't> {
                 let bi_to_ci = &inner.byte_idx_to_char_idx;
                 let mut groups = Vec::new();
 
-                for group in captures.iter_pos() {
+                for group in captures.iter() {
                     if let Some(group) = group {
                         let start = *bi_to_ci
-                            .get(&group.0)
+                            .get(&group.start())
                             .expect("byte index is at char boundary");
                         let end = *bi_to_ci
-                            .get(&group.1)
+                            .get(&group.end())
                             .expect("byte index is at char boundary");
 
                         groups.push(Group::new((start, end)));

--- a/nlprule/src/rule/grammar.rs
+++ b/nlprule/src/rule/grammar.rs
@@ -142,7 +142,8 @@ impl Match {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum SynthesizerPart {
     Text(String),
-    Match(Match),
+    // Regex with the `fancy_regex` backend is large on the stack
+    Match(Box<Match>),
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/nlprule/src/rule/grammar.rs
+++ b/nlprule/src/rule/grammar.rs
@@ -2,9 +2,8 @@ use super::engine::composition::{GraphId, MatchGraph, PosMatcher};
 use crate::types::*;
 use crate::{
     tokenizer::Tokenizer,
-    utils::{self, regex::SerializeRegex},
+    utils::{self, regex::Regex},
 };
-use onig::Captures;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
@@ -112,7 +111,7 @@ pub struct Match {
     pub(crate) id: GraphId,
     pub(crate) conversion: Conversion,
     pub(crate) pos_replacer: Option<PosReplacer>,
-    pub(crate) regex_replacer: Option<(SerializeRegex, String)>,
+    pub(crate) regex_replacer: Option<(Regex, String)>,
 }
 
 impl Match {
@@ -126,9 +125,7 @@ impl Match {
         };
 
         text = if let Some((regex, replacement)) = &self.regex_replacer {
-            regex.replace_all(&text, |caps: &Captures| {
-                utils::dollar_replace(replacement.to_string(), caps)
-            })
+            regex.replace_all(&text, replacement)
         } else {
             text
         };

--- a/nlprule/src/rule/mod.rs
+++ b/nlprule/src/rule/mod.rs
@@ -316,9 +316,22 @@ impl<'a, 't> Iterator for Suggestions<'a, 't> {
             };
             let end = end_group.char_span.1;
 
+            // this should never happen, but just return None instead of raising an Error
+            // `end` COULD be equal to `start` if the suggestion is to insert text at this position
+            if end < start {
+                return None;
+            }
+            let text_before: String = tokens[0]
+                .sentence
+                .chars()
+                .skip(start)
+                .take(end - start)
+                .collect();
+
             // fix e. g. "Super , dass"
             let replacements: Vec<String> = replacements
                 .into_iter()
+                .filter(|suggestion| *suggestion != text_before)
                 .map(|x| utils::fix_nospace_chars(&x))
                 .collect();
 

--- a/nlprule/src/utils/mod.rs
+++ b/nlprule/src/utils/mod.rs
@@ -1,8 +1,9 @@
 use lazy_static::lazy_static;
-use onig::{Captures, Regex};
 
 pub mod parallelism;
 pub mod regex;
+
+use regex::Regex;
 
 // see https://stackoverflow.com/questions/38406793/why-is-capitalizing-the-first-letter-of-a-string-so-convoluted-in-rust
 pub fn apply_to_first<F>(string: &str, func: F) -> String
@@ -29,10 +30,10 @@ pub fn is_uppercase(string: &str) -> bool {
 // remove duplicate whitespaces
 pub fn normalize_whitespace(string: &str) -> String {
     lazy_static! {
-        static ref REGEX: Regex = Regex::new(r"(\s)\s+").unwrap();
+        static ref REGEX: Regex = Regex::new(r"(\s)\s+".into());
     }
 
-    REGEX.replace_all(string, |caps: &Captures| caps.at(1).unwrap().to_string())
+    REGEX.replace_all(string, "$1")
 }
 
 #[inline]

--- a/nlprule/src/utils/mod.rs
+++ b/nlprule/src/utils/mod.rs
@@ -26,14 +26,6 @@ pub fn is_uppercase(string: &str) -> bool {
     !string.chars().any(|x| x.is_lowercase())
 }
 
-// see https://github.com/rust-onig/rust-onig/issues/59#issuecomment-340160520
-pub fn dollar_replace(mut replacement: String, caps: &Captures) -> String {
-    for i in 1..caps.len() {
-        replacement = replacement.replace(&format!("${}", i), caps.at(i).unwrap_or(""));
-    }
-    replacement
-}
-
 // remove duplicate whitespaces
 pub fn normalize_whitespace(string: &str) -> String {
     lazy_static! {

--- a/nlprule/src/utils/regex.rs
+++ b/nlprule/src/utils/regex.rs
@@ -1,70 +1,221 @@
-use onig::{Regex, RegexOptions};
-use serde::{Deserialize, Serialize, Serializer};
-use std::ops::Deref;
-use std::{
-    convert::TryFrom,
-    hash::{Hash, Hasher},
-};
+use lazycell::AtomicLazyCell;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::hash::{Hash, Hasher};
 
-impl TryFrom<String> for SerializeRegex {
-    type Error = onig::Error;
+pub use regex_impl::{Captures, CapturesIter, Match, Matches};
 
-    fn try_from(string: String) -> Result<Self, onig::Error> {
-        Ok(SerializeRegex {
-            regex: SerializeRegex::compile(&string)?,
-            string,
-        })
-    }
+#[derive(Debug)]
+pub struct Regex {
+    regex_str: String,
+    regex: AtomicLazyCell<regex_impl::Regex>,
 }
 
-#[derive(Deserialize, Debug)]
-#[serde(try_from = "String")]
-pub struct SerializeRegex {
-    pub(crate) string: String,
-    pub(crate) regex: Regex,
-}
-
-impl Serialize for SerializeRegex {
+impl Serialize for Regex {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.string)
+        serializer.serialize_str(&self.regex_str)
     }
 }
 
-impl Hash for SerializeRegex {
+impl<'de> Deserialize<'de> for Regex {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let regex_str = String::deserialize(deserializer)?;
+        Ok(Regex::new(regex_str))
+    }
+}
+
+impl Hash for Regex {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.string.hash(state);
+        self.regex_str.hash(state);
     }
 }
 
-impl SerializeRegex {
-    pub fn compile(regex_str: &str) -> Result<Regex, onig::Error> {
-        let mut case_sensitive = true;
-        let regex_str = if let Some(stripped) = regex_str.strip_suffix("(?i)") {
-            case_sensitive = false;
-            stripped
-        } else {
-            regex_str
-        };
-
-        Regex::with_options(
+impl Regex {
+    /// Create a new regex from the pattern string.
+    ///
+    /// Note that the regex compilation happens on first use, which is why this method does not
+    /// return a result.
+    pub fn new(regex_str: String) -> Self {
+        Self {
             regex_str,
-            if case_sensitive {
-                RegexOptions::REGEX_OPTION_NONE
-            } else {
-                RegexOptions::REGEX_OPTION_IGNORECASE
-            },
-            onig::Syntax::java(),
-        )
+            regex: AtomicLazyCell::new(),
+        }
+    }
+
+    /// Check whether the pattern compiles as a valid regex or not.
+    pub fn try_compile(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+        regex_impl::Regex::new(&self.regex_str).map(|_| ())
+    }
+
+    fn regex(&self) -> &regex_impl::Regex {
+        if let Some(regex) = self.regex.borrow() {
+            regex
+        } else {
+            let regex =
+                regex_impl::Regex::new(&self.regex_str).expect("regex string should be pre-tested");
+            self.regex.fill(regex).ok();
+            self.regex.borrow().unwrap()
+        }
+    }
+
+    pub fn is_match(&self, text: &str) -> bool {
+        self.regex().is_match(text)
+    }
+
+    pub fn captures_iter<'r, 't>(&'r self, text: &'t str) -> regex_impl::CapturesIter<'r, 't> {
+        self.regex().captures_iter(text)
+    }
+
+    pub fn find_iter<'r, 't>(&'r self, text: &'t str) -> regex_impl::Matches<'r, 't> {
+        self.regex().find_iter(text)
+    }
+
+    pub fn captures_len(&self) -> usize {
+        self.regex().captures_len()
+    }
+
+    pub fn captures<'t>(&self, text: &'t str) -> Option<regex_impl::Captures<'t>> {
+        self.regex().captures(text)
+    }
+
+    pub fn replace_all(&self, text: &str, replacement: &str) -> String {
+        self.regex().replace_all(text, replacement)
     }
 }
 
-impl Deref for SerializeRegex {
-    type Target = Regex;
+mod regex_impl {
+    use std::error::Error;
 
-    fn deref(&self) -> &Self::Target {
-        &self.regex
+    pub struct CapturesIter<'r, 't>(onig::FindCaptures<'r, 't>, &'t str);
+
+    pub struct Captures<'t>(onig::Captures<'t>, &'t str);
+
+    pub struct Matches<'r, 't>(onig::FindMatches<'r, 't>, &'t str);
+
+    pub struct Match<'t> {
+        text: &'t str,
+        start: usize,
+        end: usize,
+    }
+
+    impl<'t> Match<'t> {
+        pub fn start(&self) -> usize {
+            self.start
+        }
+
+        pub fn end(&self) -> usize {
+            self.end
+        }
+
+        pub fn as_str(&self) -> &'t str {
+            self.text
+        }
+    }
+
+    impl<'t> Captures<'t> {
+        pub fn get(&self, index: usize) -> Option<Match<'t>> {
+            let (start, end) = self.0.pos(index)?;
+            let text = self.0.at(index)?;
+
+            Some(Match { text, start, end })
+        }
+
+        pub fn iter(&'t self) -> impl Iterator<Item = Option<Match<'t>>> {
+            self.0.iter_pos().map(move |mat| {
+                mat.map(|(start, end)| Match {
+                    text: &self.1[start..end],
+                    start,
+                    end,
+                })
+            })
+        }
+    }
+
+    impl<'r, 't> Iterator for CapturesIter<'r, 't> {
+        type Item = Captures<'t>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.0.next().map(|x| Captures(x, self.1))
+        }
+    }
+
+    impl<'r, 't> Iterator for Matches<'r, 't> {
+        type Item = Match<'t>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.0.next().map(|(start, end)| Match {
+                text: &self.1[start..end],
+                start,
+                end,
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct Regex {
+        regex: onig::Regex,
+    }
+
+    impl Regex {
+        pub fn new(regex_str: &str) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+            let mut case_sensitive = true;
+            let regex_str = if let Some(stripped) = regex_str.strip_suffix("(?i)") {
+                case_sensitive = false;
+                stripped
+            } else {
+                regex_str
+            };
+
+            let result = onig::Regex::with_options(
+                regex_str,
+                if case_sensitive {
+                    onig::RegexOptions::REGEX_OPTION_NONE
+                } else {
+                    onig::RegexOptions::REGEX_OPTION_IGNORECASE
+                },
+                onig::Syntax::java(),
+            );
+            match result {
+                Ok(regex) => Ok(Regex { regex }),
+                Err(error) => Err(Box::new(error)),
+            }
+        }
+
+        pub fn is_match(&self, text: &str) -> bool {
+            self.regex.is_match(text)
+        }
+
+        pub fn captures_iter<'r, 't>(&'r self, text: &'t str) -> CapturesIter<'r, 't> {
+            CapturesIter(self.regex.captures_iter(text), text)
+        }
+
+        pub fn find_iter<'r, 't>(&'r self, text: &'t str) -> Matches<'r, 't> {
+            Matches(self.regex.find_iter(text), text)
+        }
+
+        pub fn captures_len(&self) -> usize {
+            self.regex.captures_len()
+        }
+
+        pub fn captures<'t>(&self, text: &'t str) -> Option<Captures<'t>> {
+            self.regex.captures(text).map(|x| Captures(x, text))
+        }
+
+        pub fn replace_all(&self, text: &str, replacement: &str) -> String {
+            self.regex.replace_all(&text, |caps: &onig::Captures| {
+                let mut replacement = replacement.to_owned();
+
+                for i in 1..caps.len() {
+                    replacement = replacement.replace(&format!("${}", i), caps.at(i).unwrap_or(""));
+                }
+
+                replacement
+            })
+        }
     }
 }

--- a/nlprule/src/utils/regex.rs
+++ b/nlprule/src/utils/regex.rs
@@ -1,3 +1,8 @@
+//! An abstraction on top of Regular Expressions to add support for Serialization and
+//! to modularize the Regex backend.
+//! Adapts the approach from https://github.com/trishume/syntect/pull/270 with feature flags for the
+//! different backends.
+
 use lazycell::AtomicLazyCell;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::hash::{Hash, Hasher};
@@ -333,6 +338,8 @@ mod regex_impl_onig {
 
 #[cfg(feature = "regex-all-test")]
 mod regex_impl_all {
+    //! This backend is only used for testing. It uses all other backends and assert they do the same thing.
+
     use super::{regex_impl_fancy as impl_fancy, regex_impl_onig as impl_onig};
     pub use impl_fancy::{CaptureMatches, Captures, Match, Matches};
     use itertools::{EitherOrBoth, Itertools};


### PR DESCRIPTION
This PR modularizes the regex backend and adds support for fancy-regex. Fixes #18. The solution is very similar to https://github.com/trishume/syntect/pull/270 with an abstraction on top of `fancy-regex` and `onig-rs` plus feature flags to switch between them. To do:

- [x] Add a `regex-test-all` feature flag which enables both backends at the same time and asserts they do the same thing (needed for tests and building the binaries).
- [x] Some doc improvements e. g. module level docs in `regex.rs`.