### PR TITLE
fs_err is underused

### DIFF
--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -2,8 +2,8 @@
 //! See `README.md` for details.
 
 use flate2::bufread::GzDecoder;
-use fs_err as fs;
 use fs::File;
+use fs_err as fs;
 use nlprule::{compile, rules_filename, tokenizer_filename};
 use std::fs::Permissions;
 use std::{

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -2,8 +2,8 @@
 //! See `README.md` for details.
 
 use flate2::bufread::GzDecoder;
-use fs::File;
 use fs_err as fs;
+use fs::File;
 use nlprule::{compile, rules_filename, tokenizer_filename};
 use std::fs::Permissions;
 use std::{

--- a/nlprule/Cargo.toml
+++ b/nlprule/Cargo.toml
@@ -49,6 +49,7 @@ quickcheck_macros = "1.0"
 
 [build-dependencies]
 serde_json = "1"
+fs-err = "2.5"
 
 [features]
 bin = ["clap", "env_logger"]

--- a/nlprule/build.rs
+++ b/nlprule/build.rs
@@ -4,10 +4,11 @@
 
 use std::{
     collections::HashMap,
-    fs::{self, File},
     io::BufWriter,
     path::Path,
 };
+use fs_err as fs;
+use fs::File;
 
 fn main() {
     let path = env!("CARGO_MANIFEST_DIR");

--- a/nlprule/build.rs
+++ b/nlprule/build.rs
@@ -2,13 +2,9 @@
 //! so they can be inlined. These configs are included at compile time because they define the neccessary parameters to
 //! run the rules for a language correctly. They are NOT user configuration.
 
-use std::{
-    collections::HashMap,
-    io::BufWriter,
-    path::Path,
-};
-use fs_err as fs;
 use fs::File;
+use fs_err as fs;
+use std::{collections::HashMap, io::BufWriter, path::Path};
 
 fn main() {
     let path = env!("CARGO_MANIFEST_DIR");

--- a/nlprule/build.rs
+++ b/nlprule/build.rs
@@ -2,8 +2,8 @@
 //! so they can be inlined. These configs are included at compile time because they define the neccessary parameters to
 //! run the rules for a language correctly. They are NOT user configuration.
 
-use fs::File;
 use fs_err as fs;
+use fs::File;
 use std::{collections::HashMap, io::BufWriter, path::Path};
 
 fn main() {

--- a/nlprule/src/compile/impls.rs
+++ b/nlprule/src/compile/impls.rs
@@ -32,7 +32,7 @@ use super::{parse_structure::BuildInfo, Error};
 
 impl MultiwordTagger {
     pub fn from_dump<P: AsRef<Path>>(dump: P, info: &BuildInfo) -> Result<Self, io::Error> {
-        let reader = BufReader::new(File::open(dump)?);
+        let reader = BufReader::new(File::open(dump.as_ref())?);
         let mut multiwords = Vec::new();
 
         for line in reader.lines() {

--- a/nlprule/src/compile/impls.rs
+++ b/nlprule/src/compile/impls.rs
@@ -1,12 +1,11 @@
 use std::{
     collections::HashMap,
-    fs::File,
     hash::{Hash, Hasher},
     io::{self, BufRead, BufReader},
     path::Path,
     sync::Arc,
 };
-
+use fs_err::File;
 use log::warn;
 use serde::{Deserialize, Serialize};
 

--- a/nlprule/src/compile/impls.rs
+++ b/nlprule/src/compile/impls.rs
@@ -1,3 +1,6 @@
+use fs_err::File;
+use log::warn;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     hash::{Hash, Hasher},
@@ -5,9 +8,6 @@ use std::{
     path::Path,
     sync::Arc,
 };
-use fs_err::File;
-use log::warn;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     rule::{

--- a/nlprule/src/compile/mod.rs
+++ b/nlprule/src/compile/mod.rs
@@ -1,7 +1,6 @@
 //! Creates the nlprule binaries from a *build directory*. Usage information in /build/README.md.
 
-use fs::File;
-use fs_err as fs;
+use fs_err::File;
 
 use std::{
     hash::{Hash, Hasher},

--- a/nlprule/src/compile/mod.rs
+++ b/nlprule/src/compile/mod.rs
@@ -1,6 +1,7 @@
 //! Creates the nlprule binaries from a *build directory*. Usage information in /build/README.md.
 
-use fs_err::File;
+use fs_err as fs;
+use fs::File;
 
 use std::{
     hash::{Hash, Hasher},

--- a/nlprule/src/compile/structure.rs
+++ b/nlprule/src/compile/structure.rs
@@ -1,5 +1,5 @@
 use serde::Deserialize;
-use std::fs::File;
+use fs_err::File;
 use std::io::BufReader;
 use xml::reader::EventReader;
 

--- a/nlprule/src/compile/structure.rs
+++ b/nlprule/src/compile/structure.rs
@@ -1,5 +1,5 @@
-use serde::Deserialize;
 use fs_err::File;
+use serde::Deserialize;
 use std::io::BufReader;
 use xml::reader::EventReader;
 

--- a/nlprule/src/compile/structure.rs
+++ b/nlprule/src/compile/structure.rs
@@ -680,7 +680,7 @@ type DisambiguationRuleReading = (DisambiguationRule, Option<Group>, Option<Cate
 pub fn read_rules<P: AsRef<std::path::Path>>(
     path: P,
 ) -> Vec<Result<GrammarRuleReading, serde_xml_rs::Error>> {
-    let file = File::open(path).unwrap();
+    let file = File::open(path.as_ref()).unwrap();
     let file = BufReader::new(file);
 
     let sanitized = preprocess::sanitize(file, &["suggestion"]);
@@ -735,7 +735,7 @@ pub fn read_rules<P: AsRef<std::path::Path>>(
 pub fn read_disambiguation_rules<P: AsRef<std::path::Path>>(
     path: P,
 ) -> Vec<Result<DisambiguationRuleReading, serde_xml_rs::Error>> {
-    let file = File::open(path).unwrap();
+    let file = File::open(path.as_ref()).unwrap();
     let file = BufReader::new(file);
 
     let sanitized = preprocess::sanitize(file, &[]);

--- a/nlprule/src/rules.rs
+++ b/nlprule/src/rules.rs
@@ -4,13 +4,13 @@ use crate::tokenizer::Tokenizer;
 use crate::types::*;
 use crate::utils::parallelism::MaybeParallelRefIterator;
 use crate::{rule::Rule, Error};
+use fs_err::File;
 use serde::{Deserialize, Serialize};
 use std::{
     io::{BufReader, Read},
     iter::{FromIterator, IntoIterator, Iterator},
     path::Path,
 };
-use fs_err::File;
 
 /// Options for a rule set.
 #[derive(Serialize, Deserialize, Clone)]

--- a/nlprule/src/rules.rs
+++ b/nlprule/src/rules.rs
@@ -6,11 +6,11 @@ use crate::utils::parallelism::MaybeParallelRefIterator;
 use crate::{rule::Rule, Error};
 use serde::{Deserialize, Serialize};
 use std::{
-    fs::File,
     io::{BufReader, Read},
     iter::{FromIterator, IntoIterator, Iterator},
     path::Path,
 };
+use fs_err::File;
 
 /// Options for a rule set.
 #[derive(Serialize, Deserialize, Clone)]

--- a/nlprule/src/rules.rs
+++ b/nlprule/src/rules.rs
@@ -48,7 +48,7 @@ impl Rules {
     /// - If the file can not be opened.
     /// - If the file content can not be deserialized to a rules set.
     pub fn new<P: AsRef<Path>>(p: P) -> Result<Self, Error> {
-        let reader = BufReader::new(File::open(p)?);
+        let reader = BufReader::new(File::open(p.as_ref())?);
         Ok(bincode::deserialize_from(reader)?)
     }
 

--- a/nlprule/src/tokenizer.rs
+++ b/nlprule/src/tokenizer.rs
@@ -9,13 +9,13 @@ use crate::{
     utils::{parallelism::MaybeParallelRefIterator, regex::SerializeRegex},
     Error,
 };
+use fs_err::File;
 use serde::{Deserialize, Serialize};
 use std::{
     io::{BufReader, Read},
     path::Path,
     sync::Arc,
 };
-use fs_err::File;
 
 pub mod chunk;
 pub mod multiword;

--- a/nlprule/src/tokenizer.rs
+++ b/nlprule/src/tokenizer.rs
@@ -128,7 +128,7 @@ impl Tokenizer {
     /// - If the file can not be opened.
     /// - If the file content can not be deserialized to a rules set.
     pub fn new<P: AsRef<Path>>(p: P) -> Result<Self, Error> {
-        let reader = BufReader::new(File::open(p)?);
+        let reader = BufReader::new(File::open(p.as_ref())?);
         Ok(bincode::deserialize_from(reader)?)
     }
 

--- a/nlprule/src/tokenizer.rs
+++ b/nlprule/src/tokenizer.rs
@@ -11,11 +11,11 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    fs::File,
     io::{BufReader, Read},
     path::Path,
     sync::Arc,
 };
+use fs_err::File;
 
 pub mod chunk;
 pub mod multiword;

--- a/nlprule/src/tokenizer/tag.rs
+++ b/nlprule/src/tokenizer/tag.rs
@@ -3,6 +3,7 @@
 
 use crate::types::*;
 use bimap::BiMap;
+use fs_err::File;
 use fst::{IntoStreamer, Map, Streamer};
 use indexmap::IndexMap;
 use log::error;
@@ -10,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::io::BufRead;
 use std::{borrow::Cow, iter::once};
 use std::{collections::HashSet, path::Path};
-use fs_err::File;
 
 #[derive(Serialize, Deserialize)]
 struct TaggerFields {

--- a/nlprule/src/tokenizer/tag.rs
+++ b/nlprule/src/tokenizer/tag.rs
@@ -8,8 +8,9 @@ use indexmap::IndexMap;
 use log::error;
 use serde::{Deserialize, Serialize};
 use std::io::BufRead;
-use std::{borrow::Cow, fs::File, iter::once};
+use std::{borrow::Cow, iter::once};
 use std::{collections::HashSet, path::Path};
+use fs_err::File;
 
 #[derive(Serialize, Deserialize)]
 struct TaggerFields {


### PR DESCRIPTION
Just bit me again, that there was a lack of information in `ValdiationError` in `nlprule-build`.

This does away with that, providing full paths for all file related io error types by using `fs_err` consistently.