### PR TITLE
nlprule-build: sure cursor is not seek'd all to the end

### DIFF
--- a/build/Cargo.toml
+++ b/build/Cargo.toml
@@ -23,3 +23,4 @@ fs-err = "2.5"
 tempdir = "0.3"
 smush = "0.1.5"
 env_logger = "0.8"
+nlprule_030 = { package = "nlprule", version = "0.3.0" }

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -656,7 +656,9 @@ mod tests {
             .join(Path::new(&tokenizer_filename("en")))
             .with_extension("bin.gz");
         assert!(tokenizer_path.exists());
-        smush::decode(&fs::read(tokenizer_path)?, smush::Codec::Gzip).unwrap();
+        let decoded = smush::decode(&fs::read(tokenizer_path)?, smush::Codec::Gzip).unwrap();
+
+        let _ = nlprule_030::Tokenizer::new_from(&mut decoded.as_slice()).unwrap();
 
         Ok(())
     }
@@ -703,6 +705,8 @@ mod tests {
 
         let mut decoded = Vec::new();
         decoder.read_to_end(&mut decoded).unwrap();
+
+        let _ = nlprule_030::Rules::new_from(&mut decoded.as_slice()).unwrap();
 
         Ok(())
     }
@@ -767,15 +771,9 @@ mod tests {
         let rules_path = tempdir
             .join(Path::new(&rules_filename("en")))
             .with_extension("bin");
-        assert!(rules_path.exists());
+        assert!(rules_path.is_file());
 
-        // The following will always fail since the versions will mismatch and rebuilding does not make sense
-        // `get_build_dir` is tested separately
-        //
-        // ```rust,no_run
-        // let _ = nlprule::Rules::new(rules_path)
-        // .map_err(|e| Error::ValidationFailed("en".to_owned(), Binary::Rules, e))?;
-        // ```
+        let _ = nlprule_030::Rules::new(rules_path).unwrap();
         Ok(())
     }
 }

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -155,6 +155,7 @@ fn obtain_binary_cache_or_github(
         let mut intermediate = Box::new(Cursor::new(Vec::<u8>::new()));
         transform_data_fn(Box::new(reader_binenc), Box::new(&mut intermediate))
             .map_err(Error::TransformError)?;
+        intermediate.seek(SeekFrom::Start(0_u64))?;
         intermediate
     } else {
         Box::new(reader_binenc)


### PR DESCRIPTION
Before the cursor was passed twice as `&mut Cursor` which lead to the second usage failing, since it was already read to the end.

Replaced by `&mut v.as_slice()` which is cheaper and does not have to be seek'd back to start.

Since transform data is short lived, the input data of `TransformDataFn` must be bound to `'r`, which is commonly equiv `'w`, but that restriction should be left to the user.