### PR TITLE
Simplify nlprule build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
           cd data
           wget https://f000.backblazeb2.com/file/nlprule/${{ matrix.lang }}.zip
           unzip ${{ matrix.lang }}.zip
-      - uses: actions-rs/cargo@v1
+      - name: Build source
+        uses: actions-rs/cargo@v1
         with:
           command: build
           args: --verbose --all-features
@@ -38,38 +39,44 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
-      - uses: actions-rs/cargo@v1
+      - name: Build binaries
+        uses: actions-rs/cargo@v1
         env:
           RUST_LOG: INFO
         with:
           command: run
           args: --all-features --bin compile -- --build-dir data/${{ matrix.lang }} --tokenizer-out storage/${{ matrix.lang }}_tokenizer.bin --rules-out storage/${{ matrix.lang }}_rules.bin
-      - uses: actions-rs/cargo@v1
+      - name: Run nlprule tests
+        uses: actions-rs/cargo@v1
         if: matrix.lang == 'en'
         with:
           command: test
-          args: --verbose --all-features -p nlprule
-      - uses: actions-rs/cargo@v1
+          args: --verbose --all-features
+      - name: Run disambiguation tests
+        uses: actions-rs/cargo@v1
         env:
             RUST_LOG: WARN
         with:
           command: run
           args: --all-features --bin test_disambiguation -- --tokenizer storage/${{ matrix.lang }}_tokenizer.bin
-      - uses: actions-rs/cargo@v1 # run with fancy-regex backend once
+      - name: Run disambiguation tests (with regex-fancy backend)
+        uses: actions-rs/cargo@v1
         if: matrix.lang == 'en'
         env:
             RUST_LOG: WARN
         with:
           command: run
           args: --manifest-path nlprule/Cargo.toml --features "bin regex-onig" --no-default-features --bin test_disambiguation -- --tokenizer storage/${{ matrix.lang }}_tokenizer.bin
-      - uses: actions-rs/cargo@v1 # run with onig backend once
+      - name: Run disambiguation tests (with regex-onig backend)
+        uses: actions-rs/cargo@v1
         if: matrix.lang == 'en'
         env:
             RUST_LOG: WARN
         with:
           command: run
           args: --manifest-path nlprule/Cargo.toml --features "bin regex-fancy" --no-default-features --bin test_disambiguation -- --tokenizer storage/${{ matrix.lang }}_tokenizer.bin
-      - uses: actions-rs/cargo@v1
+      - name: Run grammar rule tests
+        uses: actions-rs/cargo@v1
         env:
             RUST_LOG: WARN
         with:

--- a/build/Cargo.toml
+++ b/build/Cargo.toml
@@ -14,7 +14,7 @@ flate2 = "1"
 thiserror = "1"
 zip = "0.5.9"
 directories = "3"
-reqwest = { version = "0.11", default_features = false, features = ["blocking", "rustls-tls"]}
+reqwest = { version = "0.11", default_features = false, features = ["blocking", "rustls-tls"] }
 nlprule = { path = "../nlprule", features = ["compile"], version = "0.4.6" } # BUILD_BINDINGS_COMMENT
 # nlprule = { package = "nlprule-core", path = "../nlprule", features = ["compile"] } # BUILD_BINDINGS_UNCOMMENT
 fs-err = "2.5"


### PR DESCRIPTION
This PR applies the changes discussed which were out of scope for #35 by:
- making `TransformPathFn` and `TransformDataFn` a `type` instead of `trait`.
- removing the need for `Seek`s by wrapping data in cursors as late as possible.
- adjusting docs accordingly

@drahnr would be great if you could review this.