### PR TITLE
compile.rs needs clap

### DIFF
--- a/nlprule/Cargo.toml
+++ b/nlprule/Cargo.toml
@@ -74,7 +74,7 @@ compile = ["regex-syntax", "serde-xml-rs", "xml-rs", "roxmltree", "serde_json", 
 
 [[bin]]
 name = "compile"
-required-features = ["compile"]
+required-features = ["compile", "bin"]
 
 [[bin]]
 name = "test"


### PR DESCRIPTION
just running `cargo test` gives build error because compile.rs wants clap