### PR TITLE
derive more clones, add to_writer impl, restore lost api

### DIFF
--- a/nlprule/src/compile/impls.rs
+++ b/nlprule/src/compile/impls.rs
@@ -20,7 +20,7 @@ use crate::{
         id::Category,
         DisambiguationRule, Rule,
     },
-    rules::{Rules, RulesLangOptions, RulesOptions},
+    rules::{Rules, RulesLangOptions},
     tokenizer::{
         chunk,
         multiword::{MultiwordTagger, MultiwordTaggerFields},
@@ -353,10 +353,7 @@ impl Rules {
             );
         }
 
-        Rules {
-            rules,
-            options: RulesOptions::default(),
-        }
+        Rules { rules }
     }
 }
 

--- a/nlprule/src/filter/mod.rs
+++ b/nlprule/src/filter/mod.rs
@@ -4,7 +4,7 @@ use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
 
 #[enum_dispatch]
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Filter {
     NoDisambiguationEnglishPartialPosTagFilter,
 }
@@ -14,7 +14,7 @@ pub trait Filterable {
     fn keep(&self, sentence: &MatchSentence, graph: &MatchGraph) -> bool;
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NoDisambiguationEnglishPartialPosTagFilter {
     pub(crate) id: GraphId,
     pub(crate) regexp: Regex,

--- a/nlprule/src/lib.rs
+++ b/nlprule/src/lib.rs
@@ -88,8 +88,9 @@ pub use tokenizer::Tokenizer;
 pub enum Error {
     #[error(transparent)]
     Io(#[from] io::Error),
+    /// (De)serialization error. Can have occured during deserialization or during serialization.
     #[error(transparent)]
-    Deserialization(#[from] bincode::Error),
+    Serialization(#[from] bincode::Error),
     #[error(transparent)]
     IdError(#[from] rule::id::Error),
 }

--- a/nlprule/src/rule/disambiguation.rs
+++ b/nlprule/src/rule/disambiguation.rs
@@ -39,7 +39,7 @@ impl PosFilter {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Disambiguation {
     Remove(Vec<either::Either<owned::WordData, PosFilter>>),
     Add(Vec<owned::WordData>),
@@ -210,7 +210,7 @@ impl Disambiguation {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DisambiguationChange {
     pub text: String,
     pub char_span: Range<usize>,
@@ -218,7 +218,7 @@ pub struct DisambiguationChange {
     pub after: owned::Word,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum DisambiguationExample {
     Unchanged(String),
     Changed(DisambiguationChange),

--- a/nlprule/src/rule/engine/composition.rs
+++ b/nlprule/src/rule/engine/composition.rs
@@ -8,7 +8,7 @@ use unicase::UniCase;
 
 type Context<'a, 't> = (&'a MatchSentence<'t>, &'a MatchGraph<'t>);
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Matcher {
     pub matcher: either::Either<either::Either<String, GraphId>, Regex>,
     pub negate: bool,
@@ -80,7 +80,7 @@ impl Matcher {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub(crate) struct TextMatcher {
     pub(crate) matcher: Matcher,
     pub(crate) set: Option<DefaultHashSet<WordIdInt>>,
@@ -119,7 +119,7 @@ impl PosMatcher {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct WordDataMatcher {
     pub(crate) pos_matcher: Option<PosMatcher>,
     pub(crate) inflect_matcher: Option<TextMatcher>,
@@ -153,7 +153,7 @@ impl WordDataMatcher {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Quantifier {
     pub min: usize,
     pub max: usize,
@@ -165,7 +165,7 @@ pub trait Atomable: Send + Sync {
 }
 
 #[enum_dispatch(Atomable)]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Atom {
     ChunkAtom(concrete::ChunkAtom),
     SpaceBeforeAtom(concrete::SpaceBeforeAtom),
@@ -183,7 +183,7 @@ pub mod concrete {
     use super::{Atomable, Context, Matcher, TextMatcher, WordDataMatcher};
     use serde::{Deserialize, Serialize};
 
-    #[derive(Debug, Serialize, Deserialize)]
+    #[derive(Debug, Serialize, Deserialize, Clone)]
     pub struct TextAtom {
         pub(crate) matcher: TextMatcher,
     }
@@ -197,7 +197,7 @@ pub mod concrete {
         }
     }
 
-    #[derive(Debug, Serialize, Deserialize)]
+    #[derive(Debug, Serialize, Deserialize, Clone)]
     pub struct ChunkAtom {
         pub(crate) matcher: Matcher,
     }
@@ -211,7 +211,7 @@ pub mod concrete {
         }
     }
 
-    #[derive(Debug, Serialize, Deserialize)]
+    #[derive(Debug, Serialize, Deserialize, Clone)]
     pub struct SpaceBeforeAtom {
         pub(crate) value: bool,
     }
@@ -224,7 +224,7 @@ pub mod concrete {
         }
     }
 
-    #[derive(Debug, Serialize, Deserialize)]
+    #[derive(Debug, Serialize, Deserialize, Clone)]
     pub struct WordDataAtom {
         pub(crate) matcher: WordDataMatcher,
         pub(crate) case_sensitive: bool,
@@ -241,7 +241,7 @@ pub mod concrete {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct TrueAtom {}
 
 impl Atomable for TrueAtom {
@@ -250,7 +250,7 @@ impl Atomable for TrueAtom {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct FalseAtom {}
 
 impl Atomable for FalseAtom {
@@ -259,7 +259,7 @@ impl Atomable for FalseAtom {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AndAtom {
     pub(crate) atoms: Vec<Atom>,
 }
@@ -270,7 +270,7 @@ impl Atomable for AndAtom {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct OrAtom {
     pub(crate) atoms: Vec<Atom>,
 }
@@ -281,7 +281,7 @@ impl Atomable for OrAtom {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NotAtom {
     pub(crate) atom: Box<Atom>,
 }
@@ -292,7 +292,7 @@ impl Atomable for NotAtom {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct OffsetAtom {
     pub(crate) atom: Box<Atom>,
     pub(crate) offset: isize,
@@ -489,7 +489,7 @@ impl<'t> MatchGraph<'t> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Part {
     pub atom: Atom,
     pub quantifier: Quantifier,
@@ -498,7 +498,7 @@ pub struct Part {
     pub unify: Option<bool>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Composition {
     pub(crate) parts: Vec<Part>,
     pub(crate) id_to_idx: DefaultHashMap<GraphId, usize>,

--- a/nlprule/src/rule/engine/mod.rs
+++ b/nlprule/src/rule/engine/mod.rs
@@ -7,7 +7,7 @@ pub mod composition;
 
 use composition::{Composition, GraphId, Group, MatchGraph, MatchSentence};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TokenEngine {
     pub(crate) composition: Composition,
     pub(crate) antipatterns: Vec<Composition>,
@@ -52,7 +52,7 @@ impl TokenEngine {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Engine {
     Token(TokenEngine),
     // regex with the `fancy_regex` backend is large on the stack

--- a/nlprule/src/rule/grammar.rs
+++ b/nlprule/src/rule/grammar.rs
@@ -3,7 +3,7 @@ use crate::types::*;
 use crate::utils::{self, regex::Regex};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Conversion {
     Nop,
     AllLower,
@@ -25,7 +25,7 @@ impl Conversion {
 }
 
 /// An example associated with a [Rule][crate::rule::Rule].
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Example {
     pub(crate) text: String,
     pub(crate) suggestion: Option<Suggestion>,
@@ -45,7 +45,7 @@ impl Example {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PosReplacer {
     pub(crate) matcher: PosMatcher,
 }
@@ -85,7 +85,7 @@ impl PosReplacer {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Match {
     pub(crate) id: GraphId,
     pub(crate) conversion: Conversion,
@@ -118,14 +118,14 @@ impl Match {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum SynthesizerPart {
     Text(String),
     // Regex with the `fancy_regex` backend is large on the stack
     Match(Box<Match>),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Synthesizer {
     pub(crate) use_titlecase_adjust: bool,
     pub(crate) parts: Vec<SynthesizerPart>,

--- a/nlprule/src/rule/mod.rs
+++ b/nlprule/src/rule/mod.rs
@@ -31,7 +31,7 @@ use self::{
 /// A *Unification* makes an otherwise matching pattern invalid if no combination of its filters
 /// matches all tokens marked with "unify".
 /// Can also be negated.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct Unification {
     pub(crate) mask: Vec<Option<bool>>,
     pub(crate) filters: Vec<Vec<PosFilter>>,
@@ -81,7 +81,7 @@ impl Unification {
 ///    <disambig action="replace"><wd lemma="have" pos="VB"></wd></disambig>
 /// </rule>
 /// ```
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DisambiguationRule {
     pub(crate) id: Index,
     pub(crate) engine: Engine,
@@ -371,7 +371,7 @@ impl<'a, 't> Iterator for Suggestions<'a, 't> {
 ///     <example correction="doesn't">He <marker>dosn't</marker> know about it.</example>
 /// </rule>
 /// ```
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Rule {
     pub(crate) id: Index,
     pub(crate) engine: Engine,

--- a/nlprule/src/tokenizer.rs
+++ b/nlprule/src/tokenizer.rs
@@ -14,7 +14,7 @@ use crate::{
 use fs_err::File;
 use serde::{Deserialize, Serialize};
 use std::{
-    io::{BufReader, Read},
+    io::{BufReader, Read, Write},
     ops::Range,
     path::Path,
     sync::Arc,
@@ -153,7 +153,7 @@ impl<'t> Iterator for SentenceIter<'t> {
 }
 
 /// The complete Tokenizer doing tagging, chunking and disambiguation.
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 pub struct Tokenizer {
     pub(crate) rules: Vec<DisambiguationRule>,
     pub(crate) chunker: Option<Chunker>,
@@ -177,6 +177,11 @@ impl Tokenizer {
     /// Creates a new tokenizer from a reader.
     pub fn from_reader<R: Read>(reader: R) -> Result<Self, Error> {
         Ok(bincode::deserialize_from(reader)?)
+    }
+
+    /// Serializes this rules set to a writer.
+    pub fn to_writer<W: Write>(&self, writer: W) -> Result<(), Error> {
+        Ok(bincode::serialize_into(writer, &self)?)
     }
 
     /// Gets all disambigation rules in the order they are applied.

--- a/nlprule/src/tokenizer/chunk.rs
+++ b/nlprule/src/tokenizer/chunk.rs
@@ -303,7 +303,7 @@ impl Model {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct MaxentTokenizer {
     pub(crate) model: Model,
 }
@@ -433,7 +433,7 @@ impl MaxentTokenizer {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct MaxentPosTagger {
     pub(crate) model: Model,
     pub(crate) tagdict: DefaultHashMap<String, Vec<String>>,
@@ -559,7 +559,7 @@ impl MaxentPosTagger {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct MaxentChunker {
     pub(crate) model: Model,
 }
@@ -700,7 +700,7 @@ impl MaxentChunker {
 
 /// Predicts noun chunks and verb chunks through a [Maximum Entropy Model](https://www.aclweb.org/anthology/W00-0729.pdf).
 /// Grammatical number (i. e. singular and plural) is also assigned through the part-of-speech tags of the tokens.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Chunker {
     pub(crate) token_model: MaxentTokenizer,
     pub(crate) pos_model: MaxentPosTagger,

--- a/nlprule/src/tokenizer/multiword.rs
+++ b/nlprule/src/tokenizer/multiword.rs
@@ -28,7 +28,7 @@ impl From<MultiwordTaggerFields> for MultiwordTagger {
 ///
 /// They key difference to the [Tagger][crate::tokenizer::tag::Tagger] is that this tagger looks at sequences of tokens
 /// instead of at one token at a time.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(from = "MultiwordTaggerFields")]
 pub struct MultiwordTagger {
     #[serde(skip)]

--- a/nlprule/src/types.rs
+++ b/nlprule/src/types.rs
@@ -27,7 +27,7 @@ pub mod owned {
     use super::*;
     use serde::{Deserialize, Serialize};
 
-    #[derive(Debug, Serialize, Deserialize, Hash, Eq, PartialEq)]
+    #[derive(Debug, Serialize, Deserialize, Hash, Eq, PartialEq, Clone)]
     /// See [super::WordId].
     pub struct WordId(pub(crate) String, pub(crate) Option<WordIdInt>);
 
@@ -45,7 +45,7 @@ pub mod owned {
     }
 
     /// See [super::PosId].
-    #[derive(Debug, Serialize, Deserialize, Hash, Eq, PartialEq)]
+    #[derive(Debug, Serialize, Deserialize, Hash, Eq, PartialEq, Clone)]
     pub struct PosId(pub(crate) String, pub(crate) PosIdInt);
 
     impl PosId {
@@ -62,7 +62,7 @@ pub mod owned {
     }
 
     /// See [super::WordData].
-    #[derive(Debug, Serialize, Deserialize, Hash, Eq, PartialEq)]
+    #[derive(Debug, Serialize, Deserialize, Hash, Eq, PartialEq, Clone)]
     #[allow(missing_docs)]
     pub struct WordData {
         pub lemma: WordId,
@@ -77,7 +77,7 @@ pub mod owned {
     }
 
     /// See [super::Word].
-    #[derive(Debug, Serialize, Deserialize)]
+    #[derive(Debug, Serialize, Deserialize, Hash, Eq, PartialEq, Clone)]
     #[allow(missing_docs)]
     pub struct Word {
         pub text: WordId,
@@ -85,7 +85,7 @@ pub mod owned {
     }
 
     /// See [super::Token].
-    #[derive(Debug, Serialize, Deserialize)]
+    #[derive(Debug, Serialize, Deserialize, Hash, Eq, PartialEq, Clone)]
     #[allow(missing_docs)]
     pub struct Token {
         pub word: Word,
@@ -586,7 +586,7 @@ impl Sub for Position {
 
 /// A span in a text determined by start (inclusive) and end (exclusive) position.
 /// The start must always be greater than or equal to the end.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
 pub struct Span {
     byte: Range<usize>,
     char: Range<usize>,


### PR DESCRIPTION
This should fix #57. Would be great if you could take a quick look @drahnr, I'll then merge and release.

I also added `Clone` derives, that was possible through the lazy Regex initialization now.