### PR TITLE
Remove `multiword_tags` on Tokens, reduce dependents on Tokenizer, add SpecialPos

### DIFF
--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -594,12 +594,8 @@ mod tests {
         let tempdir = tempdir::TempDir::new("builder_test")?;
         let tempdir = tempdir.path();
 
-        let build_tempdir = tempdir::TempDir::new("builder_build_dir_test")?;
-        let build_tempdir = build_tempdir.path().into();
-
         BinaryBuilder::new(&["en"], tempdir)
             .fallback_to_build_dir(true)
-            .build_dir(Some(build_tempdir)) // to avoid problems with cached build dirs
             .build()?
             .validate()?;
 

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -594,9 +594,12 @@ mod tests {
         let tempdir = tempdir::TempDir::new("builder_test")?;
         let tempdir = tempdir.path();
 
+        let build_tempdir = tempdir::TempDir::new("builder_build_dir_test")?;
+        let build_tempdir = build_tempdir.path().into();
+
         BinaryBuilder::new(&["en"], tempdir)
             .fallback_to_build_dir(true)
-            .cache_dir(None)
+            .build_dir(Some(build_tempdir)) // to avoid problems with cached build dirs
             .build()?
             .validate()?;
 

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -596,6 +596,7 @@ mod tests {
 
         BinaryBuilder::new(&["en"], tempdir)
             .fallback_to_build_dir(true)
+            .cache_dir(None)
             .build()?
             .validate()?;
 

--- a/nlprule/Cargo.toml
+++ b/nlprule/Cargo.toml
@@ -52,10 +52,15 @@ serde_json = { version = "1", optional = true }
 [dev-dependencies]
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
+criterion = "0.3"
 
 [build-dependencies]
 serde_json = "1"
 fs-err = "2.5"
+
+[[bench]]
+name = "load"
+harness = false
 
 [features]
 default = ["regex-onig"]

--- a/nlprule/benches/load.rs
+++ b/nlprule/benches/load.rs
@@ -1,0 +1,15 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use nlprule::{Rules, Tokenizer};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("load tokenizer", |b| {
+        b.iter(|| Tokenizer::new(black_box("../storage/en_tokenizer.bin")).unwrap())
+    });
+
+    c.bench_function("load rules", |b| {
+        b.iter(|| Rules::new(black_box("../storage/en_rules.bin")).unwrap())
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/nlprule/configs/de/tagger.json
+++ b/nlprule/configs/de/tagger.json
@@ -4,5 +4,6 @@
     "extra_tags": [
         "PKT",
         "PRO:IND:DAT:SIN:NEU"
-    ]
+    ],
+    "retain_last": false
 }

--- a/nlprule/configs/de/tokenizer.json
+++ b/nlprule/configs/de/tokenizer.json
@@ -1,6 +1,5 @@
 {
     "allow_errors": false,
-    "retain_last": false,
     "ignore_ids": [
         "DISAMBIGUATION/SUB_BEAMTE/1",
         "DISAMBIGUATION/SUB_BEAMTE/2"

--- a/nlprule/configs/en/tagger.json
+++ b/nlprule/configs/en/tagger.json
@@ -6,5 +6,6 @@
         "ORD",
         "SYM",
         "RB_SENT"
-    ]
+    ],
+    "retain_last": true
 }

--- a/nlprule/configs/en/tokenizer.json
+++ b/nlprule/configs/en/tokenizer.json
@@ -1,6 +1,5 @@
 {
     "allow_errors": false,
-    "retain_last": true,
     "ignore_ids": [
         "DISAMBIGUATION/BEST_JJS/0"
     ],

--- a/nlprule/configs/es/tagger.json
+++ b/nlprule/configs/es/tagger.json
@@ -60,5 +60,6 @@
         "NCCN00",
         "LOC_CC",
         "LOC_I"
-    ]
+    ],
+    "retain_last": true
 }

--- a/nlprule/configs/es/tokenizer.json
+++ b/nlprule/configs/es/tokenizer.json
@@ -1,6 +1,5 @@
 {
     "allow_errors": true,
-    "retain_last": true,
     "ignore_ids": [],
     "extra_split_chars": [
         "-",

--- a/nlprule/src/compile/parse_structure.rs
+++ b/nlprule/src/compile/parse_structure.rs
@@ -1115,16 +1115,23 @@ impl DisambiguationRule {
 
                 Ok(Disambiguation::Filter(
                     disambiguations.into_iter().collect(),
+                    info.tagger().lang_options().retain_last,
                 ))
             }
             Some("filter") => {
                 if let Some(postag) = data.disambig.postag.as_ref() {
-                    Ok(Disambiguation::Filter(vec![Some(either::Right(
-                        parse_pos_filter(postag, Some("yes"), info),
-                    ))]))
+                    Ok(Disambiguation::Filter(
+                        vec![Some(either::Right(parse_pos_filter(
+                            postag,
+                            Some("yes"),
+                            info,
+                        )))],
+                        info.tagger().lang_options().retain_last,
+                    ))
                 } else {
                     Ok(Disambiguation::Filter(
                         word_datas.into_iter().map(Some).collect(),
+                        info.tagger().lang_options().retain_last,
                     ))
                 }
             }
@@ -1181,15 +1188,17 @@ impl DisambiguationRule {
             }
             None => {
                 if let Some(postag) = data.disambig.postag.as_ref() {
-                    Ok(Disambiguation::Filter(vec![Some(either::Left(
-                        owned::WordData::new(
+                    Ok(Disambiguation::Filter(
+                        vec![Some(either::Left(owned::WordData::new(
                             info.tagger.id_word("".into()).to_owned_id(),
                             info.tagger.id_tag(postag).to_owned_id(),
-                        ),
-                    ))]))
+                        )))],
+                        info.tagger().lang_options().retain_last,
+                    ))
                 } else {
                     Ok(Disambiguation::Filter(
                         word_datas.into_iter().map(Some).collect(),
+                        info.tagger().lang_options().retain_last,
                     ))
                 }
             }

--- a/nlprule/src/filter/mod.rs
+++ b/nlprule/src/filter/mod.rs
@@ -32,7 +32,7 @@ impl Filterable for NoDisambiguationEnglishPartialPosTagFilter {
                     .get_tags(&captures.get(1).unwrap().as_str());
 
                 tags.iter()
-                    .any(|x| self.postag_regexp.is_match(x.pos().as_ref()))
+                    .any(|x| self.postag_regexp.is_match(x.pos().as_str()))
             } else {
                 false
             }

--- a/nlprule/src/filter/mod.rs
+++ b/nlprule/src/filter/mod.rs
@@ -26,13 +26,13 @@ pub struct NoDisambiguationEnglishPartialPosTagFilter {
 impl Filterable for NoDisambiguationEnglishPartialPosTagFilter {
     fn keep(&self, sentence: &MatchSentence, graph: &MatchGraph) -> bool {
         graph.by_id(self.id).tokens(sentence).all(|token| {
-            if let Some(captures) = self.regexp.captures(&token.word().text.as_ref()) {
+            if let Some(captures) = self.regexp.captures(&token.word().as_str()) {
                 let tags = sentence
                     .tagger()
                     .get_tags(&captures.get(1).unwrap().as_str());
 
                 tags.iter()
-                    .any(|x| self.postag_regexp.is_match(x.pos.as_ref()))
+                    .any(|x| self.postag_regexp.is_match(x.pos().as_ref()))
             } else {
                 false
             }

--- a/nlprule/src/lib.rs
+++ b/nlprule/src/lib.rs
@@ -57,8 +57,8 @@
 //! let sentence = tokenizer.pipe(text).next().expect("`text` contains one sentence.");
 //!
 //! println!("{:#?}", sentence);
-//! assert_eq!(sentence.tokens()[1].word().text.as_ref(), "brief");
-//! assert_eq!(sentence.tokens()[1].word().tags[0].pos.as_ref(), "JJ");
+//! assert_eq!(sentence.tokens()[1].word().text().as_str(), "brief");
+//! assert_eq!(sentence.tokens()[1].word().tags()[0].pos().as_str(), "JJ");
 //! assert_eq!(sentence.tokens()[1].chunks(), vec!["I-NP-singular"]);
 //! // some other information like char / byte span, lemmas etc. is also set!
 //! # Ok::<(), nlprule::Error>(())

--- a/nlprule/src/rule/disambiguation.rs
+++ b/nlprule/src/rule/disambiguation.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use crate::{tokenizer::tag::Tagger, types::*};
+use crate::types::*;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
@@ -50,12 +50,7 @@ pub enum Disambiguation {
 }
 
 impl Disambiguation {
-    pub fn apply<'t>(
-        &'t self,
-        groups: Vec<Vec<&mut IncompleteToken<'t>>>,
-        retain_last: bool,
-        tagger: &'t Tagger,
-    ) {
+    pub fn apply<'t>(&'t self, groups: Vec<Vec<&mut IncompleteToken<'t>>>, retain_last: bool) {
         match self {
             Disambiguation::Remove(data_or_filters) => {
                 for (group, data_or_filter) in groups.into_iter().zip(data_or_filters) {
@@ -127,7 +122,7 @@ impl Disambiguation {
                         );
 
                         token.word_mut().push(data);
-                        token.word_mut().retain(|x| !x.pos().as_ref().is_empty());
+                        token.word_mut().retain(|x| !x.pos().as_str().is_empty());
                     }
                 }
             }
@@ -156,7 +151,7 @@ impl Disambiguation {
                 for (group, use_mask_val) in groups.iter().zip(mask) {
                     for token in group.iter() {
                         if *use_mask_val {
-                            let finalized: Token = (*token).clone().into_token(tagger);
+                            let finalized: Token = (*token).clone().into_token();
 
                             for (mask_val, filter) in filter_mask.iter_mut().zip(filters.iter()) {
                                 *mask_val = *mask_val && PosFilter::and(filter, finalized.word());

--- a/nlprule/src/rule/disambiguation.rs
+++ b/nlprule/src/rule/disambiguation.rs
@@ -44,13 +44,16 @@ pub enum Disambiguation {
     Remove(Vec<either::Either<owned::WordData, PosFilter>>),
     Add(Vec<owned::WordData>),
     Replace(Vec<owned::WordData>),
-    Filter(Vec<Option<either::Either<owned::WordData, PosFilter>>>),
+    Filter(
+        Vec<Option<either::Either<owned::WordData, PosFilter>>>,
+        bool,
+    ),
     Unify(Vec<Vec<PosFilter>>, Vec<Option<PosFilter>>, Vec<bool>),
     Nop,
 }
 
 impl Disambiguation {
-    pub fn apply<'t>(&'t self, groups: Vec<Vec<&mut IncompleteToken<'t>>>, retain_last: bool) {
+    pub fn apply<'t>(&'t self, groups: Vec<Vec<&mut IncompleteToken<'t>>>) {
         match self {
             Disambiguation::Remove(data_or_filters) => {
                 for (group, data_or_filter) in groups.into_iter().zip(data_or_filters) {
@@ -70,7 +73,7 @@ impl Disambiguation {
                     }
                 }
             }
-            Disambiguation::Filter(filters) => {
+            Disambiguation::Filter(filters, retain_last) => {
                 for (group, maybe_filter) in groups.into_iter().zip(filters) {
                     if let Some(data_or_filter) = maybe_filter {
                         match data_or_filter {
@@ -86,7 +89,7 @@ impl Disambiguation {
                                         .retain(|x| *x.pos() == limit.pos.as_ref_id());
 
                                     if token.word().tags().is_empty() {
-                                        if retain_last {
+                                        if *retain_last {
                                             token
                                                 .word_mut()
                                                 .push(WordData::new(last, limit.pos.as_ref_id()));

--- a/nlprule/src/rule/disambiguation.rs
+++ b/nlprule/src/rule/disambiguation.rs
@@ -13,25 +13,25 @@ pub struct PosFilter {
 
 impl PosFilter {
     fn is_word_data_match(&self, data: &WordData) -> bool {
-        self.matcher.is_match(&data.pos)
+        self.matcher.is_match(data.pos())
     }
 
     fn keep(&self, data: &mut Word) {
-        data.tags.retain(|x| self.is_word_data_match(x))
+        data.retain(|x| self.is_word_data_match(x))
     }
 
     fn remove(&self, data: &mut Word) {
-        data.tags.retain(|x| !self.is_word_data_match(x))
+        data.retain(|x| !self.is_word_data_match(x))
     }
 
     pub fn and(filters: &[&Self], data: &Word) -> bool {
-        data.tags
+        data.tags()
             .iter()
             .any(|x| filters.iter().all(|filter| filter.is_word_data_match(x)))
     }
 
     pub fn apply(filters: &[Vec<&Self>], data: &mut Word) {
-        data.tags.retain(|x| {
+        data.retain(|x| {
             filters
                 .iter()
                 .any(|filter| filter.iter().all(|f| f.is_word_data_match(x)))
@@ -62,10 +62,10 @@ impl Disambiguation {
                     for token in group.into_iter() {
                         match data_or_filter {
                             either::Left(data) => {
-                                token.word_mut().tags.retain(|x| {
-                                    !(x.pos == data.pos.as_ref_id()
+                                token.word_mut().retain(|x| {
+                                    !(*x.pos() == data.pos.as_ref_id()
                                         && (data.lemma.as_ref().is_empty()
-                                            || x.lemma == data.lemma.as_ref_id()))
+                                            || *x.lemma() == data.lemma.as_ref_id()))
                                 });
                             }
                             either::Right(filter) => {
@@ -81,28 +81,25 @@ impl Disambiguation {
                         match data_or_filter {
                             either::Left(limit) => {
                                 for token in group.into_iter() {
-                                    let last = token.word().tags.get(0).map_or_else(
-                                        || token.word().text.clone(),
-                                        |x| x.lemma.clone(),
+                                    let last = token.word().tags().get(0).map_or_else(
+                                        || token.word().text().clone(),
+                                        |x| x.lemma().clone(),
                                     );
 
                                     token
                                         .word_mut()
-                                        .tags
-                                        .retain(|x| x.pos == limit.pos.as_ref_id());
+                                        .retain(|x| *x.pos() == limit.pos.as_ref_id());
 
-                                    if token.word().tags.is_empty() {
+                                    if token.word().tags().is_empty() {
                                         if retain_last {
                                             token
                                                 .word_mut()
-                                                .tags
                                                 .push(WordData::new(last, limit.pos.as_ref_id()));
                                         } else {
-                                            let lemma = token.word().text.clone();
+                                            let lemma = token.word().text().clone();
 
                                             token
                                                 .word_mut()
-                                                .tags
                                                 .push(WordData::new(lemma, limit.pos.as_ref_id()));
                                         }
                                     }
@@ -122,15 +119,15 @@ impl Disambiguation {
                     for token in group.into_iter() {
                         let data = WordData::new(
                             if data.lemma.as_ref().is_empty() {
-                                token.word().text.clone()
+                                token.word().text().clone()
                             } else {
                                 data.lemma.as_ref_id()
                             },
                             data.pos.as_ref_id(),
                         );
 
-                        token.word_mut().tags.push(data);
-                        token.word_mut().tags.retain(|x| !x.pos.as_ref().is_empty());
+                        token.word_mut().push(data);
+                        token.word_mut().retain(|x| !x.pos().as_ref().is_empty());
                     }
                 }
             }
@@ -139,15 +136,15 @@ impl Disambiguation {
                     for token in group.into_iter() {
                         let data = WordData::new(
                             if data.lemma.as_ref().is_empty() {
-                                token.word().text.clone()
+                                token.word().text().clone()
                             } else {
                                 data.lemma.as_ref_id()
                             },
                             data.pos.as_ref_id(),
                         );
 
-                        token.word_mut().tags.clear();
-                        token.word_mut().tags.push(data);
+                        token.word_mut().clear();
+                        token.word_mut().push(data);
                     }
                 }
             }
@@ -198,7 +195,7 @@ impl Disambiguation {
                                 disambig.keep(token.word_mut());
                             }
 
-                            if token.word().tags.is_empty() {
+                            if token.word().tags().is_empty() {
                                 *token.word_mut() = before;
                             }
                         }

--- a/nlprule/src/rule/engine/composition.rs
+++ b/nlprule/src/rule/engine/composition.rs
@@ -62,9 +62,9 @@ impl Matcher {
                         .next()
                         .map_or(false, |token| {
                             if case_sensitive {
-                                token.word().text.as_ref() == input
+                                token.word().as_str() == input
                             } else {
-                                UniCase::new(token.word().text.as_ref()) == UniCase::new(input)
+                                UniCase::new(token.word().as_str()) == UniCase::new(input)
                             }
                         })
                 }
@@ -136,7 +136,7 @@ impl WordDataMatcher {
             let pos_matches = self
                 .pos_matcher
                 .as_ref()
-                .map_or(true, |m| m.is_match(&x.pos));
+                .map_or(true, |m| m.is_match(x.pos()));
 
             // matching part-of-speech tag is faster than inflection, so check POS first and early exit if it doesn't match
             if !pos_matches {
@@ -146,7 +146,7 @@ impl WordDataMatcher {
             let inflect_matches = self
                 .inflect_matcher
                 .as_ref()
-                .map_or(true, |m| m.is_match(&x.lemma, context, case_sensitive));
+                .map_or(true, |m| m.is_match(x.lemma(), context, case_sensitive));
 
             inflect_matches
         })
@@ -193,7 +193,7 @@ pub mod concrete {
             let (sentence, _) = context;
 
             self.matcher
-                .is_match(&sentence.index(position).word().text, Some(context), None)
+                .is_match(&sentence.index(position).word().text(), Some(context), None)
         }
     }
 
@@ -233,7 +233,7 @@ pub mod concrete {
     impl Atomable for WordDataAtom {
         fn is_match(&self, context: Context, position: usize) -> bool {
             let (sentence, _) = context;
-            let tags = &sentence.index(position).word().tags;
+            let tags = &sentence.index(position).word().tags();
 
             self.matcher
                 .is_match(&tags, Some(context), Some(self.case_sensitive))

--- a/nlprule/src/rule/engine/composition.rs
+++ b/nlprule/src/rule/engine/composition.rs
@@ -96,14 +96,14 @@ impl TextMatcher {
         if self.set.is_none() {
             return self
                 .matcher
-                .is_match(word_id.as_ref(), context, case_sensitive);
+                .is_match(word_id.as_str(), context, case_sensitive);
         }
 
         if let Some(id) = word_id.id() {
             self.set.as_ref().unwrap().contains(id)
         } else {
             self.matcher
-                .is_match(word_id.as_ref(), context, case_sensitive)
+                .is_match(word_id.as_str(), context, case_sensitive)
         }
     }
 }
@@ -115,7 +115,7 @@ pub struct PosMatcher {
 
 impl PosMatcher {
     pub fn is_match(&self, pos: &PosId) -> bool {
-        self.mask[pos.id().0 as usize]
+        self.mask[pos.id().value() as usize]
     }
 }
 
@@ -370,7 +370,7 @@ impl<'t> MatchSentence<'t> {
     pub fn new(sentence: &'t Sentence<'t>) -> Self {
         MatchSentence {
             sentence,
-            sent_start: sentence.tagger().sent_start(),
+            sent_start: Token::sent_start(),
         }
     }
 

--- a/nlprule/src/rule/grammar.rs
+++ b/nlprule/src/rule/grammar.rs
@@ -59,14 +59,14 @@ impl PosReplacer {
             .map(|x| {
                 let group_words = sentence
                     .tagger()
-                    .get_group_members(&x.lemma.as_ref().to_string());
+                    .get_group_members(&x.lemma().as_ref().to_string());
                 let mut data = Vec::new();
                 for word in group_words {
                     if let Some(i) = sentence
                         .tagger()
                         .get_tags(word)
                         .iter()
-                        .position(|x| self.matcher.is_match(&x.pos))
+                        .position(|x| self.matcher.is_match(x.pos()))
                     {
                         data.push((word.to_string(), i));
                     }
@@ -168,8 +168,7 @@ impl Synthesizer {
                     (self.use_titlecase_adjust
                         && first_token
                             .word()
-                            .text
-                            .as_ref()
+                            .as_str()
                             .chars()
                             .next() // a word is expected to always have at least one char, but be defensive here
                             .map_or(false, char::is_uppercase))

--- a/nlprule/src/rule/grammar.rs
+++ b/nlprule/src/rule/grammar.rs
@@ -57,9 +57,7 @@ impl PosReplacer {
             .get_tags(text)
             .iter()
             .map(|x| {
-                let group_words = sentence
-                    .tagger()
-                    .get_group_members(&x.lemma().as_ref().to_string());
+                let group_words = sentence.tagger().get_group_members(&x.lemma().as_str());
                 let mut data = Vec::new();
                 for word in group_words {
                     if let Some(i) = sentence

--- a/nlprule/src/rule/mod.rs
+++ b/nlprule/src/rule/mod.rs
@@ -226,7 +226,7 @@ impl DisambiguationRule {
 
                     let unordered_tags = after
                         .word()
-                        .tags
+                        .tags()
                         .iter()
                         .map(|x| x.to_owned_word_data())
                         .collect::<HashSet<owned::WordData>>();
@@ -238,7 +238,7 @@ impl DisambiguationRule {
                         .iter()
                         .collect::<HashSet<&owned::WordData>>();
 
-                    after.word().text == change.after.text.as_ref_id()
+                    after.word().as_str() == change.after.text.as_ref_id().as_ref()
                         && unordered_tags == unordered_tags_change
                 }
             };

--- a/nlprule/src/rule/mod.rs
+++ b/nlprule/src/rule/mod.rs
@@ -172,11 +172,8 @@ impl DisambiguationRule {
                 groups.push(group);
             }
 
-            self.disambiguations.apply(
-                groups,
-                tokenizer.lang_options().retain_last,
-                tokenizer.tagger(),
-            );
+            self.disambiguations
+                .apply(groups, tokenizer.lang_options().retain_last);
         }
     }
 
@@ -238,7 +235,7 @@ impl DisambiguationRule {
                         .iter()
                         .collect::<HashSet<&owned::WordData>>();
 
-                    after.word().as_str() == change.after.text.as_ref_id().as_ref()
+                    after.word().as_str() == change.after.text.as_ref_id().as_str()
                         && unordered_tags == unordered_tags_change
                 }
             };

--- a/nlprule/src/rule/mod.rs
+++ b/nlprule/src/rule/mod.rs
@@ -147,12 +147,7 @@ impl DisambiguationRule {
         Changes(all_byte_spans)
     }
 
-    pub(crate) fn change<'t>(
-        &'t self,
-        sentence: &mut IncompleteSentence<'t>,
-        tokenizer: &'t Tokenizer,
-        changes: Changes,
-    ) {
+    pub(crate) fn change<'t>(&'t self, sentence: &mut IncompleteSentence<'t>, changes: Changes) {
         log::info!("applying {}", self.id);
 
         for byte_spans in changes.0 {
@@ -172,8 +167,7 @@ impl DisambiguationRule {
                 groups.push(group);
             }
 
-            self.disambiguations
-                .apply(groups, tokenizer.lang_options().retain_last);
+            self.disambiguations.apply(groups);
         }
     }
 
@@ -201,7 +195,7 @@ impl DisambiguationRule {
             let mut sentence_after = sentence_before.clone();
 
             if !changes.is_empty() {
-                self.change(&mut sentence_after, tokenizer, changes);
+                self.change(&mut sentence_after, changes);
             }
 
             info!("Tokens: {:#?}", sentence_before);

--- a/nlprule/src/tokenizer.rs
+++ b/nlprule/src/tokenizer.rs
@@ -326,7 +326,7 @@ impl Tokenizer {
                 let is_sentence_end = i == n_token_strs - 1;
 
                 IncompleteToken::new(
-                    Word::new_with_tags(
+                    Word::new(
                         self.tagger.id_word(token_text.into()),
                         self.tagger.get_tags_with_options(
                             token_text,
@@ -341,7 +341,6 @@ impl Tokenizer {
                     is_sentence_end,
                     sentence[..byte_start].ends_with(char::is_whitespace),
                     Vec::new(),
-                    None,
                 )
             })
             .collect();

--- a/nlprule/src/tokenizer.rs
+++ b/nlprule/src/tokenizer.rs
@@ -57,9 +57,6 @@ where
 pub(crate) struct TokenizerLangOptions {
     /// Whether to allow errors while constructing the tokenizer.
     pub allow_errors: bool,
-    /// Whether to retain the last tag if disambiguation leads to an empty tag.
-    /// Language-specific in LT so it has to be an option.
-    pub retain_last: bool,
     /// Disambiguation Rule selectors to use in this tokenizer.
     #[serde(default)]
     pub ids: Vec<Selector>,
@@ -81,7 +78,6 @@ impl Default for TokenizerLangOptions {
     fn default() -> Self {
         TokenizerLangOptions {
             allow_errors: false,
-            retain_last: false,
             ids: Vec::new(),
             ignore_ids: Vec::new(),
             known_failures: Vec::new(),
@@ -231,7 +227,7 @@ impl Tokenizer {
                 .find_first(|_| true);
 
             if let Some((index, changes)) = result {
-                self.rules[index].change(&mut sentence, &self, changes);
+                self.rules[index].change(&mut sentence, changes);
                 i = index + 1;
             } else {
                 i = n;

--- a/nlprule/src/tokenizer/chunk.rs
+++ b/nlprule/src/tokenizer/chunk.rs
@@ -768,9 +768,9 @@ impl Chunker {
                         .map(|token| {
                             token
                                 .word()
-                                .tags
+                                .tags()
                                 .iter()
-                                .any(|tag| tag.pos.as_ref() == "NNS")
+                                .any(|tag| tag.pos().as_ref() == "NNS")
                         })
                         .unwrap_or(false);
 

--- a/nlprule/src/tokenizer/chunk.rs
+++ b/nlprule/src/tokenizer/chunk.rs
@@ -770,7 +770,7 @@ impl Chunker {
                                 .word()
                                 .tags()
                                 .iter()
-                                .any(|tag| tag.pos().as_ref() == "NNS")
+                                .any(|tag| tag.pos().as_str() == "NNS")
                         })
                         .unwrap_or(false);
 

--- a/nlprule/src/tokenizer/multiword.rs
+++ b/nlprule/src/tokenizer/multiword.rs
@@ -50,11 +50,11 @@ impl MultiwordTagger {
             .enumerate()
             .map(|(i, x)| {
                 start_indices.insert(byte_index, i);
-                byte_index += x.word().text.0.len();
+                byte_index += x.word().text().0.len();
                 end_indices.insert(byte_index, i);
                 byte_index += " ".len();
 
-                x.word().text.0.as_ref()
+                x.word().as_str()
             })
             .collect::<Vec<_>>()
             .join(" ");
@@ -66,10 +66,11 @@ impl MultiwordTagger {
                 let (word, pos) = &self.multiwords[m.pattern()];
                 // end index is inclusive
                 for token in sentence.iter_mut().skip(*start).take((end + 1) - start) {
-                    *token.multiword_data_mut() = Some(WordData::new(
-                        tagger.id_word(word.as_str().into()),
-                        pos.as_ref_id(),
-                    ));
+                    let mut data =
+                        WordData::new(tagger.id_word(word.as_str().into()), pos.as_ref_id());
+                    data.freeze();
+
+                    token.word_mut().push(data);
                 }
             }
         }

--- a/nlprule/src/tokenizer/tag.rs
+++ b/nlprule/src/tokenizer/tag.rs
@@ -14,6 +14,7 @@ use std::{borrow::Cow, fmt, iter::once};
 pub(crate) struct WordIdInt(u32);
 
 impl WordIdInt {
+    #[allow(dead_code)] // used in compile module
     pub(crate) fn from_value_unchecked(value: u32) -> Self {
         WordIdInt(value)
     }
@@ -24,6 +25,7 @@ impl WordIdInt {
 pub(crate) struct PosIdInt(u16);
 
 impl PosIdInt {
+    #[allow(dead_code)] // used in compile module
     pub(crate) fn from_value_unchecked(value: u16) -> Self {
         PosIdInt(value)
     }
@@ -86,6 +88,7 @@ impl SpecialPos {
         }
     }
 
+    #[allow(dead_code)] // used in compile module
     pub fn iter() -> impl Iterator<Item = &'static str> + 'static {
         [
             SpecialPos::None,
@@ -330,6 +333,7 @@ impl Tagger {
         }
     }
 
+    #[allow(dead_code)] // used in compile module
     pub(crate) fn lang_options(&self) -> &TaggerLangOptions {
         &self.lang_options
     }

--- a/nlprule/src/tokenizer/tag.rs
+++ b/nlprule/src/tokenizer/tag.rs
@@ -308,12 +308,13 @@ impl Tagger {
                     if !next_tags.is_empty() {
                         tags = next_tags
                             .into_iter()
-                            .map(|mut x| {
-                                x.lemma = self.id_word(
-                                    format!("{}{}", &word[..i], x.lemma.as_ref().to_lowercase())
+                            .map(|x| {
+                                let lemma = self.id_word(
+                                    format!("{}{}", &word[..i], x.lemma().as_ref().to_lowercase())
                                         .into(),
                                 );
-                                x
+
+                                WordData::new(lemma, *x.pos())
                             })
                             .collect();
                         break;

--- a/nlprule/src/tokenizer/tag.rs
+++ b/nlprule/src/tokenizer/tag.rs
@@ -5,10 +5,150 @@ use crate::types::*;
 use bimap::BiMap;
 use fst::{IntoStreamer, Map, Streamer};
 use indexmap::IndexMap;
-use lazycell::AtomicLazyCell;
 use log::error;
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, iter::once};
+use std::{borrow::Cow, fmt, iter::once};
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[serde(transparent)]
+pub(crate) struct WordIdInt(u32);
+
+impl WordIdInt {
+    pub(crate) fn from_value_unchecked(value: u32) -> Self {
+        WordIdInt(value)
+    }
+}
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[serde(transparent)]
+pub(crate) struct PosIdInt(u16);
+
+impl PosIdInt {
+    pub(crate) fn from_value_unchecked(value: u16) -> Self {
+        PosIdInt(value)
+    }
+
+    pub fn value(&self) -> u16 {
+        self.0
+    }
+}
+
+/// A potentially identified word. If it is identified as a known word, many optimizations can be applied.
+#[derive(Clone, PartialEq)]
+pub struct WordId<'t>(pub(crate) Cow<'t, str>, pub(crate) Option<WordIdInt>);
+
+impl<'t> fmt::Debug for WordId<'t> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let id_str = if let Some(id) = self.1 {
+            id.0.to_string()
+        } else {
+            "none".into()
+        };
+
+        write!(f, "{:?}<id={}>", self.0, id_str)
+    }
+}
+
+impl<'t> WordId<'t> {
+    pub(crate) fn to_owned_id(&self) -> owned::WordId {
+        owned::WordId(self.0.to_string(), self.1)
+    }
+
+    pub(crate) fn id(&self) -> &Option<WordIdInt> {
+        &self.1
+    }
+
+    pub(crate) fn empty() -> Self {
+        WordId("".into(), Some(WordIdInt(0)))
+    }
+
+    /// Gets the word as string.
+    pub fn as_str(&'t self) -> &'t str {
+        self.0.as_ref()
+    }
+}
+
+#[derive(Copy, Clone, PartialEq)]
+pub(crate) enum SpecialPos {
+    None = 0,
+    Unknown = 1,
+    SentStart = 2,
+    SentEnd = 3,
+}
+
+impl SpecialPos {
+    pub fn as_str(&self) -> &'static str {
+        match &self {
+            SpecialPos::None => "",
+            SpecialPos::Unknown => "UNKNOWN",
+            SpecialPos::SentStart => "SENT_START",
+            SpecialPos::SentEnd => "SENT_END",
+        }
+    }
+
+    pub fn iter() -> impl Iterator<Item = &'static str> + 'static {
+        [
+            SpecialPos::None,
+            SpecialPos::Unknown,
+            SpecialPos::SentStart,
+            SpecialPos::SentEnd,
+        ]
+        .iter()
+        .map(|pos| pos.as_str())
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum InnerPosId<'t> {
+    Normal(&'t str, PosIdInt),
+    Special(SpecialPos),
+}
+
+/// An identified part-of-speech tag. POS tags are treated as a closed set so every POS tag is identified.
+#[derive(Clone, Copy, PartialEq)]
+pub struct PosId<'t> {
+    inner: InnerPosId<'t>,
+}
+
+impl<'t> fmt::Debug for PosId<'t> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}<id={}>", self.as_str(), self.id().0)
+    }
+}
+
+impl<'t> PosId<'t> {
+    pub(crate) fn regular(text: &'t str, id: PosIdInt) -> Self {
+        PosId {
+            inner: InnerPosId::Normal(text, id),
+        }
+    }
+
+    pub(crate) fn special(special: SpecialPos) -> Self {
+        PosId {
+            inner: InnerPosId::Special(special),
+        }
+    }
+
+    /// Converts this ID to an owned ID.
+    pub fn to_owned_id(&self) -> owned::PosId {
+        owned::PosId(self.as_str().to_string(), self.id())
+    }
+
+    pub(crate) fn id(&self) -> PosIdInt {
+        match &self.inner {
+            InnerPosId::Normal(_, id) => *id,
+            InnerPosId::Special(special) => PosIdInt(*special as u16),
+        }
+    }
+
+    /// Gets the part-of-speech as string.
+    pub fn as_str(&self) -> &'t str {
+        match &self.inner {
+            InnerPosId::Normal(text, _) => *text,
+            InnerPosId::Special(special) => special.as_str(),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct TaggerLangOptions {
@@ -147,7 +287,6 @@ impl From<TaggerFields> for Tagger {
             word_store,
             groups,
             lang_options: data.lang_options,
-            ..Default::default()
         }
     }
 }
@@ -161,7 +300,6 @@ pub struct Tagger {
     pub(crate) word_store: BiMap<String, WordIdInt>,
     pub(crate) groups: DefaultHashMap<WordIdInt, Vec<WordIdInt>>,
     pub(crate) lang_options: TaggerLangOptions,
-    pub(crate) sent_start: AtomicLazyCell<Token<'static>>,
 }
 
 impl Tagger {
@@ -207,15 +345,6 @@ impl Tagger {
         tags
     }
 
-    pub(crate) fn sent_start(&self) -> &Token<'static> {
-        if let Some(token) = self.sent_start.borrow() {
-            token
-        } else {
-            self.sent_start.fill(Token::sent_start(&self)).ok();
-            self.sent_start.borrow().unwrap()
-        }
-    }
-
     #[allow(dead_code)] // used by compile module
     pub(crate) fn tag_store(&self) -> &BiMap<String, PosIdInt> {
         &self.tag_store
@@ -241,7 +370,7 @@ impl Tagger {
     /// Tags the given string representation of a part-of-speech tag.
     /// Part-of-speech tags are treated as a closed set so each valid part-of-speech tag will get a numerical id.
     pub fn id_tag<'a>(&self, tag: &'a str) -> PosId<'a> {
-        PosId(
+        PosId::regular(
             tag,
             *self.tag_store.get_by_left(tag).unwrap_or_else(|| {
                 error!(
@@ -265,7 +394,7 @@ impl Tagger {
     /// # Arguments
     /// * `word`: The word to lookup data for.
     /// * `add_lower`: Whether to add data for the lowercase variant of the word.
-    ///     If `None`, will be set according to the language options.
+    ///     If `None`, will be set according to the language options.
     /// * `use_compound_split_heuristic`: Whether to use a heuristic to split compound words.
     ///     If `None`, will be set according to the language options.
     /// If true, will attempt to find tags for words which are longer than some cutoff and unknown by looking up tags
@@ -310,7 +439,7 @@ impl Tagger {
                             .into_iter()
                             .map(|x| {
                                 let lemma = self.id_word(
-                                    format!("{}{}", &word[..i], x.lemma().as_ref().to_lowercase())
+                                    format!("{}{}", &word[..i], x.lemma().as_str().to_lowercase())
                                         .into(),
                                 );
 

--- a/nlprule/src/tokenizer/tag.rs
+++ b/nlprule/src/tokenizer/tag.rs
@@ -158,6 +158,9 @@ pub(crate) struct TaggerLangOptions {
     pub always_add_lower_tags: bool,
     /// Used part-of-speech tags which are not in the tagger dictionary.
     pub extra_tags: Vec<String>,
+    /// Whether to retain the last tag if disambiguation leads to an empty tag.
+    /// Language-specific in LT so it has to be an option.
+    pub retain_last: bool,
 }
 
 impl Default for TaggerLangOptions {
@@ -166,6 +169,7 @@ impl Default for TaggerLangOptions {
             use_compound_split_heuristic: false,
             always_add_lower_tags: false,
             extra_tags: Vec::new(),
+            retain_last: false,
         }
     }
 }
@@ -324,6 +328,10 @@ impl Tagger {
         } else {
             Vec::new()
         }
+    }
+
+    pub(crate) fn lang_options(&self) -> &TaggerLangOptions {
+        &self.lang_options
     }
 
     fn get_strict_tags(

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -136,7 +136,7 @@ impl PyTagger {
         self.tagger
             .get_tags_with_options(word, add_lower, use_compound_split_heuristic)
             .into_iter()
-            .map(|x| (x.lemma().as_ref().to_string(), x.pos().as_ref().to_string()))
+            .map(|x| (x.lemma().as_str().to_string(), x.pos().as_str().to_string()))
             .collect()
     }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -136,7 +136,7 @@ impl PyTagger {
         self.tagger
             .get_tags_with_options(word, add_lower, use_compound_split_heuristic)
             .into_iter()
-            .map(|x| (x.lemma.as_ref().to_string(), x.pos.as_ref().to_string()))
+            .map(|x| (x.lemma().as_ref().to_string(), x.pos().as_ref().to_string()))
             .collect()
     }
 


### PR DESCRIPTION
This PR fixes some things needed for better modularization:
- Removes the `multiword_tags` field on tokens and instead adds the possibility for tags to be frozen (i.e. impossible to remove).
- Moves the `retain_last` option to the Tagger so that `DisambiguationRule::change` does not depend on the Tokenizer anymore.
- makes sure that special POS tags (`UNKNOWN`, `SENT_START`, `SENT_END`, ``) always get the same ID to allow construction without the tokenizer. This also allows the `SENT_START` Token to be constructed in a `lazy_static` now.
- Also adds some `as_str` convenience methods and as a result avoids some string clones which were not obvious before.