### PR TITLE
fix bug with matching logic assuming sentence starts from index 0

### DIFF
--- a/nlprule/src/rule/engine/composition.rs
+++ b/nlprule/src/rule/engine/composition.rs
@@ -335,15 +335,12 @@ impl Group {
         })
     }
 
-    pub fn text<'a>(&self, text: &'a str) -> &'a str {
+    pub fn text<'a>(&self, sentence: &'a MatchSentence<'a>) -> &'a str {
         if self.span.char().start >= self.span.char().end {
             return "";
         }
 
-        let mut char_indices: Vec<_> = text.char_indices().map(|(i, _)| i).collect();
-        char_indices.push(text.len());
-
-        &text[char_indices[self.span.char().start]..char_indices[self.span.char().end]]
+        sentence.slice(self.span.clone())
     }
 }
 
@@ -391,6 +388,11 @@ impl<'t> MatchSentence<'t> {
 
     pub fn text(&self) -> &str {
         self.sentence.text()
+    }
+
+    pub fn slice(&self, span: Span) -> &str {
+        let span = span.lshift(self.span().start());
+        &self.text()[span.byte().clone()]
     }
 
     pub fn tagger(&self) -> &'t Tagger {

--- a/nlprule/src/rule/engine/mod.rs
+++ b/nlprule/src/rule/engine/mod.rs
@@ -125,7 +125,10 @@ impl<'a, 't> Iterator for EngineMatches<'a, 't> {
                             .get(&byte_span.end)
                             .expect("byte index is at char boundary");
 
-                        groups.push(Group::new(Span::new(byte_span, char_start..char_end)));
+                        groups.push(Group::new(
+                            Span::new(byte_span, char_start..char_end)
+                                .rshift(sentence.span().start()),
+                        ));
                     } else {
                         groups.push(Group::new(Span::default()));
                     }

--- a/nlprule/src/rule/grammar.rs
+++ b/nlprule/src/rule/grammar.rs
@@ -93,7 +93,7 @@ pub struct Match {
 
 impl Match {
     fn apply(&self, sentence: &MatchSentence, graph: &MatchGraph) -> Option<String> {
-        let text = graph.by_id(self.id).text(sentence.text());
+        let text = graph.by_id(self.id).text(sentence);
 
         let mut text = if let Some(replacer) = &self.pos_replacer {
             replacer.apply(text, sentence)?
@@ -170,7 +170,7 @@ impl Synthesizer {
                             .chars()
                             .next() // a word is expected to always have at least one char, but be defensive here
                             .map_or(false, char::is_uppercase))
-                        || first_token.span().byte().start == 0
+                        || first_token.span().start() == sentence.span().start()
                 })
                 .unwrap_or(false);
 

--- a/nlprule/src/types.rs
+++ b/nlprule/src/types.rs
@@ -721,4 +721,10 @@ impl Suggestion {
         self.span = self.span.rshift(position);
         self
     }
+
+    /// Shift the span left by the specified amount.
+    pub fn lshift(mut self, position: Position) -> Self {
+        self.span = self.span.lshift(position);
+        self
+    }
 }


### PR DESCRIPTION
@drahnr This is the fix. It also removes the call to `.char_indices`. Now the tests run with a shifted input position, so coverage should be good again.

I'll look over this once more a bit later and then merge + release.