### PR TITLE
Improve tagger: Return iterators over `WordData`, remove groups, parallelize deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 0.6.4
+
+## Internal improvements
+
+- Decrease time it takes to load the `Tokenizer` by ~ 40% (#70).
+- Tag lookup is backed by a vector instead of a hashmap now.
+
+## Breaking changes
+
+- The tagger now returns iterators over tags instead of allocating a vector.
+- Remove `get_group_members` function.
+
+# 0.6.3
+
+## Fixes
+
+- Fix a bug where calling `Rule::suggest` in parallel across threads would cause a panic (#68, thanks @drahnr!)
+
 # 0.6.2
 
 ## Internal improvements

--- a/nlprule/benches/load.rs
+++ b/nlprule/benches/load.rs
@@ -1,15 +1,31 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use nlprule::{Rules, Tokenizer};
+use std::time::Duration;
 
-fn criterion_benchmark(c: &mut Criterion) {
+fn parse_tokenizer(c: &mut Criterion) {
     c.bench_function("load tokenizer", |b| {
         b.iter(|| Tokenizer::new(black_box("../storage/en_tokenizer.bin")).unwrap())
     });
+}
 
+fn parse_rules(c: &mut Criterion) {
     c.bench_function("load rules", |b| {
         b.iter(|| Rules::new(black_box("../storage/en_rules.bin")).unwrap())
     });
 }
 
-criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);
+
+fn no_warmup_criterion() -> Criterion {
+	let crit = Criterion::default().sample_size(20).warm_up_time(Duration::from_nanos(1));
+	crit
+}
+
+criterion_group!(
+name = parse;
+config = no_warmup_criterion();
+targets =
+	parse_rules,
+	parse_tokenizer,
+);
+
+criterion_main!(parse);

--- a/nlprule/benches/load.rs
+++ b/nlprule/benches/load.rs
@@ -14,18 +14,18 @@ fn parse_rules(c: &mut Criterion) {
     });
 }
 
-
 fn no_warmup_criterion() -> Criterion {
-	let crit = Criterion::default().sample_size(20).warm_up_time(Duration::from_nanos(1));
-	crit
+    Criterion::default()
+        .sample_size(20)
+        .warm_up_time(Duration::from_nanos(1))
 }
 
 criterion_group!(
 name = parse;
 config = no_warmup_criterion();
 targets =
-	parse_rules,
-	parse_tokenizer,
+    parse_rules,
+    parse_tokenizer,
 );
 
 criterion_main!(parse);

--- a/nlprule/src/compile/impls.rs
+++ b/nlprule/src/compile/impls.rs
@@ -146,24 +146,17 @@ impl Tagger {
             .collect();
 
         let mut tags: WordIdMap<Vec<(WordIdInt, PosIdInt)>> = WordIdMap::new(word_store.len());
-        let mut groups: WordIdMap<Vec<WordIdInt>> = WordIdMap::new(word_store.len());
 
         for (word, inflection, tag) in lines.iter() {
             let word_id = word_store.get_by_left(word).unwrap();
             let lemma_id = word_store.get_by_left(inflection).unwrap();
             let pos_id = tag_store.get_by_left(tag).unwrap();
 
-            let group = groups.get_mut_or_default(*lemma_id);
-            if !group.contains(word_id) {
-                group.push(*word_id);
-            }
-
             tags.get_mut_or_default(*word_id).push((*lemma_id, *pos_id));
         }
 
         Ok(Tagger {
             tags,
-            groups,
             word_store,
             tag_store,
             lang_options,

--- a/nlprule/src/compile/impls.rs
+++ b/nlprule/src/compile/impls.rs
@@ -145,18 +145,25 @@ impl Tagger {
             .map(|(i, x)| (x.to_string(), PosIdInt::from_value_unchecked(i as u16)))
             .collect();
 
-        let mut tags: WordIdMap<Vec<(WordIdInt, PosIdInt)>> = WordIdMap::new(word_store.len());
+        let mut tags: Vec<Option<Vec<(WordIdInt, PosIdInt)>>> = vec![None; word_store.len()];
 
         for (word, inflection, tag) in lines.iter() {
             let word_id = word_store.get_by_left(word).unwrap();
             let lemma_id = word_store.get_by_left(inflection).unwrap();
             let pos_id = tag_store.get_by_left(tag).unwrap();
 
-            tags.get_mut_or_default(*word_id).push((*lemma_id, *pos_id));
+            match &mut tags[word_id.value() as usize] {
+                Some(vec) => {
+                    vec.push((*lemma_id, *pos_id));
+                }
+                None => {
+                    tags[word_id.value() as usize] = Some(vec![(*lemma_id, *pos_id)]);
+                }
+            }
         }
 
         Ok(Tagger {
-            tags,
+            tags: WordIdMap(tags),
             word_store,
             tag_store,
             lang_options,

--- a/nlprule/src/compile/parse_structure.rs
+++ b/nlprule/src/compile/parse_structure.rs
@@ -380,6 +380,7 @@ fn parse_match(m: structure::Match, engine: &Engine, info: &mut BuildInfo) -> Re
         || m.postag_replace.is_some()
         || m.text.is_some()
     {
+        // this would need a fully functional PosReplacer to work
         return Err(Error::Unimplemented(
             "postag, postag_regex, postag_replace and text in `match` are not implemented.".into(),
         ));

--- a/nlprule/src/filter/mod.rs
+++ b/nlprule/src/filter/mod.rs
@@ -27,12 +27,11 @@ impl Filterable for NoDisambiguationEnglishPartialPosTagFilter {
     fn keep(&self, sentence: &MatchSentence, graph: &MatchGraph) -> bool {
         graph.by_id(self.id).tokens(sentence).all(|token| {
             if let Some(captures) = self.regexp.captures(&token.word().as_str()) {
-                let tags = sentence
+                let mut tags = sentence
                     .tagger()
                     .get_tags(&captures.get(1).unwrap().as_str());
 
-                tags.iter()
-                    .any(|x| self.postag_regexp.is_match(x.pos().as_str()))
+                tags.any(|x| self.postag_regexp.is_match(x.pos().as_str()))
             } else {
                 false
             }

--- a/nlprule/src/rule/grammar.rs
+++ b/nlprule/src/rule/grammar.rs
@@ -51,35 +51,9 @@ pub struct PosReplacer {
 }
 
 impl PosReplacer {
-    fn apply(&self, text: &str, sentence: &MatchSentence) -> Option<String> {
-        let mut candidates: Vec<_> = sentence
-            .tagger()
-            .get_tags(text)
-            .iter()
-            .map(|x| {
-                let group_words = sentence.tagger().get_group_members(&x.lemma().as_str());
-                let mut data = Vec::new();
-                for word in group_words {
-                    if let Some(i) = sentence
-                        .tagger()
-                        .get_tags(word)
-                        .iter()
-                        .position(|x| self.matcher.is_match(x.pos()))
-                    {
-                        data.push((word.to_string(), i));
-                    }
-                }
-                data
-            })
-            .rev()
-            .flatten()
-            .collect();
-        candidates.sort_by(|(_, a), (_, b)| a.cmp(b));
-        if candidates.is_empty() {
-            None
-        } else {
-            Some(candidates.remove(0).0)
-        }
+    fn apply(&self, _text: &str, _sentence: &MatchSentence) -> Option<String> {
+        // TODO: needs to be implemented with correct ordering, currently rules which would need this are disabled
+        unimplemented!()
     }
 }
 

--- a/nlprule/src/tokenizer.rs
+++ b/nlprule/src/tokenizer.rs
@@ -324,11 +324,13 @@ impl Tokenizer {
                 IncompleteToken::new(
                     Word::new(
                         self.tagger.id_word(token_text.into()),
-                        self.tagger.get_tags_with_options(
-                            token_text,
-                            if is_sentence_start { Some(true) } else { None },
-                            None,
-                        ),
+                        self.tagger
+                            .get_tags_with_options(
+                                token_text,
+                                if is_sentence_start { Some(true) } else { None },
+                                None,
+                            )
+                            .collect(),
                     ),
                     Span::new(
                         byte_start..byte_start + token_text.len(),

--- a/nlprule/src/tokenizer/tag.rs
+++ b/nlprule/src/tokenizer/tag.rs
@@ -16,10 +16,14 @@ use std::{
 #[serde(transparent)]
 pub(crate) struct WordIdInt(u32);
 
+#[allow(dead_code)] // used in compile module
 impl WordIdInt {
-    #[allow(dead_code)] // used in compile module
     pub(crate) fn from_value_unchecked(value: u32) -> Self {
         WordIdInt(value)
+    }
+
+    pub fn value(&self) -> u32 {
+        self.0
     }
 }
 
@@ -368,37 +372,14 @@ impl From<TaggerFields> for Tagger {
 }
 
 #[derive(Default, Serialize, Deserialize, Clone)]
-pub(crate) struct WordIdMap<T>(Vec<Option<T>>);
+pub(crate) struct WordIdMap<T>(pub Vec<Option<T>>);
 
 impl<T: Clone + Default> WordIdMap<T> {
-    pub fn new(n_ids: usize) -> Self {
-        WordIdMap(vec![None; n_ids])
-    }
-
     pub fn get(&self, id: &WordIdInt) -> Option<&T> {
         self.0
             .get(id.0 as usize)
             .map(|value| value.as_ref())
             .flatten()
-    }
-
-    pub fn get_mut(&mut self, id: &WordIdInt) -> Option<&mut T> {
-        self.0
-            .get_mut(id.0 as usize)
-            .map(|value| value.as_mut())
-            .flatten()
-    }
-
-    pub fn get_mut_or_default(&mut self, id: WordIdInt) -> &mut T {
-        if self.get(&id).is_none() {
-            self.insert(id, T::default());
-        }
-
-        self.get_mut(&id).unwrap()
-    }
-
-    pub fn insert(&mut self, id: WordIdInt, value: T) {
-        self.0[id.0 as usize] = Some(value);
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (WordIdInt, &T)> {

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -140,17 +140,6 @@ impl PyTagger {
             .map(|x| (x.lemma().as_str().to_string(), x.pos().as_str().to_string()))
             .collect()
     }
-
-    /// Get the words with the same lemma as the given lemma.
-    ///
-    /// Arguments:
-    ///     lemma (str): The lemma.
-    ///
-    /// Returns:
-    ///     group_members (List[str]): The words in the dictionary with the same lemma.
-    fn get_group_members(&self, lemma: &str) -> Vec<&str> {
-        self.tagger.get_group_members(&lemma.to_string())
-    }
 }
 
 impl PyTagger {


### PR DESCRIPTION
I had another look at the tagger today. This PR:
- Changes all the `get_tags_*` methods to return iterators instead of `Vec`.
- Removes the `groups`. These were only used by nlprule in the `PosReplacer` which wasn't used anywhere as it is not fully implemented. Some of the currently unimplemented rules might need the `groups` in some form though, but we can probably get away with search + caching since the groups are only needed if a rule actually matches there.
- Iterates over the FST in parallel in chunks with disjoint words, this allows populating the `tags` without synchronization.
- Replaces the word `HashMap` with a `Vec` since the IDs go from zero to `n_words` anyway, so we don't need to hash anything.

I see another ~ 30% speedup in loading the Tokenizer. This could also have positive impact on rule checking speed, but there's some weird behavior in the local benchmark on my PC so I have to double check.

@drahnr you might be interested in this PR. It would also be great if you could double check the speedup.