### PR TITLE
chore: improve benches a bit

### DIFF
--- a/nlprule/benches/load.rs
+++ b/nlprule/benches/load.rs
@@ -1,15 +1,31 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use nlprule::{Rules, Tokenizer};
+use std::time::Duration;
 
-fn criterion_benchmark(c: &mut Criterion) {
+fn parse_tokenizer(c: &mut Criterion) {
     c.bench_function("load tokenizer", |b| {
         b.iter(|| Tokenizer::new(black_box("../storage/en_tokenizer.bin")).unwrap())
     });
+}
 
+fn parse_rules(c: &mut Criterion) {
     c.bench_function("load rules", |b| {
         b.iter(|| Rules::new(black_box("../storage/en_rules.bin")).unwrap())
     });
 }
 
-criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);
+
+fn no_warmup_criterion() -> Criterion {
+	let crit = Criterion::default().sample_size(20).warm_up_time(Duration::from_nanos(1));
+	crit
+}
+
+criterion_group!(
+name = parse;
+config = no_warmup_criterion();
+targets =
+	parse_rules,
+	parse_tokenizer,
+);
+
+criterion_main!(parse);


### PR DESCRIPTION
Removing the warmup increases stddev, but gives a better impression on the worst case - which for the cli case is `+5%` (worse). Percentages are relative to the previous run with 1 second warmup.

```
Benchmarking load rules: Warming up for 1.0000 ns
Warning: Unable to complete 20 samples in 5.0s. You may wish to increase target time to 7.0s, enable flat sampling, or reduce sample count to 10.
load rules              time:   [31.713 ms 31.858 ms 31.974 ms]                      
                        change: [-1.5281% +0.1387% +1.6864%] (p = 0.89 > 0.05)
                        No change in performance detected.

Benchmarking load tokenizer: Warming up for 1.0000 ns
Warning: Unable to complete 20 samples in 5.0s. You may wish to increase target time to 7.9s, or reduce sample count to 10.
load tokenizer          time:   [355.07 ms 360.05 ms 365.65 ms]                         
                        change: [+0.3144% +2.8350% +5.0645%] (p = 0.02 < 0.05)
                        Change within noise threshold.
```